### PR TITLE
feat: add command to merge duplicate ingredients by name_slug and cou…

### DIFF
--- a/app/Console/Commands/DataMaintenance/MergeDuplicateIngredientsCommand.php
+++ b/app/Console/Commands/DataMaintenance/MergeDuplicateIngredientsCommand.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\DataMaintenance;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'data-maintenance:merge-duplicate-ingredients')]
+class MergeDuplicateIngredientsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'data-maintenance:merge-duplicate-ingredients
+                            {--dry-run : Show what would be done without making changes}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Merge duplicate ingredients by name_slug and country_id';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->components->warn('DRY RUN - No changes will be made');
+        }
+
+        $duplicates = $this->findDuplicates();
+
+        if ($duplicates === []) {
+            $this->components->info('No duplicate ingredients found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->components->info(sprintf('Found %d duplicate groups to merge.', count($duplicates)));
+
+        $totalMerged = 0;
+        $totalDeleted = 0;
+        $totalPivotsMoved = 0;
+        $totalDuplicatePivotsRemoved = 0;
+
+        foreach ($duplicates as $duplicate) {
+            $result = $this->mergeDuplicateGroup($duplicate, $dryRun);
+            $totalMerged++;
+            $totalDeleted += $result['deleted'];
+            $totalPivotsMoved += $result['pivots_moved'];
+            $totalDuplicatePivotsRemoved += $result['duplicate_pivots_removed'];
+        }
+
+        $this->newLine();
+        $this->components->info('Summary:');
+        $this->table(
+            ['Metric', 'Count'],
+            [
+                ['Duplicate groups merged', $totalMerged],
+                ['Ingredients deleted', $totalDeleted],
+                ['Pivot entries moved', $totalPivotsMoved],
+                ['Duplicate pivots removed', $totalDuplicatePivotsRemoved],
+            ]
+        );
+
+        if ($dryRun) {
+            $this->newLine();
+            $this->components->warn('DRY RUN - No changes were made. Run without --dry-run to apply.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Find all duplicate ingredient groups.
+     *
+     * @return array<int, array{name_slug: string, country_id: int, ids: non-empty-list<int>, count: int}>
+     */
+    protected function findDuplicates(): array
+    {
+        return DB::table('ingredients')
+            ->select([
+                'name_slug',
+                'country_id',
+                DB::raw('ARRAY_AGG(id ORDER BY id) as ids'),
+                DB::raw('COUNT(*) as count'),
+            ])
+            ->groupBy(['name_slug', 'country_id'])
+            ->havingRaw('COUNT(*) > 1')
+            ->orderByDesc('count')
+            ->get()
+            ->map(function (object $row): array {
+                // Parse PostgreSQL array format {1,2,3} to PHP array
+                $ids = trim((string) $row->ids, '{}');
+
+                return [
+                    'name_slug' => (string) $row->name_slug,
+                    'country_id' => (int) $row->country_id,
+                    'ids' => array_map(intval(...), explode(',', $ids)),
+                    'count' => (int) $row->count,
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * Merge a single duplicate group.
+     *
+     * @param  array{name_slug: string, country_id: int, ids: non-empty-list<int>, count: int}  $duplicate
+     * @return array{deleted: int, pivots_moved: int, duplicate_pivots_removed: int}
+     */
+    protected function mergeDuplicateGroup(array $duplicate, bool $dryRun): array
+    {
+        $keepId = $duplicate['ids'][0]; // Keep the lowest ID
+        $deleteIds = array_slice($duplicate['ids'], 1);
+
+        $this->components->twoColumnDetail(
+            sprintf('<fg=yellow>%s</> (country: %d)', $duplicate['name_slug'], $duplicate['country_id']),
+            sprintf('Keep ID %d, delete ', $keepId) . implode(', ', $deleteIds)
+        );
+
+        $result = [
+            'deleted' => count($deleteIds),
+            'pivots_moved' => 0,
+            'duplicate_pivots_removed' => 0,
+        ];
+
+        if ($dryRun) {
+            // Count what would be moved
+            $result['pivots_moved'] = DB::table('ingredient_recipe')
+                ->whereIn('ingredient_id', $deleteIds)
+                ->count();
+
+            return $result;
+        }
+
+        DB::transaction(function () use ($keepId, $deleteIds, &$result): void {
+            // 1. Merge hellofresh_ids from all duplicates into the keeper
+            $this->mergeHelloFreshIds($keepId, $deleteIds);
+
+            // 2. Move pivot entries, handling duplicates
+            $result['pivots_moved'] = $this->movePivotEntries($keepId, $deleteIds);
+
+            // 3. Remove duplicate pivot entries (same ingredient_id + recipe_id)
+            $result['duplicate_pivots_removed'] = $this->removeDuplicatePivots($keepId);
+
+            // 4. Delete the duplicate ingredients
+            DB::table('ingredients')->whereIn('id', $deleteIds)->delete();
+        });
+
+        return $result;
+    }
+
+    /**
+     * Merge hellofresh_ids from duplicates into the keeper.
+     *
+     * @param  list<int>  $deleteIds
+     */
+    protected function mergeHelloFreshIds(int $keepId, array $deleteIds): void
+    {
+        $allIds = array_merge([$keepId], $deleteIds);
+
+        // Get all hellofresh_ids from all duplicates
+        $allHelloFreshIds = DB::table('ingredients')
+            ->whereIn('id', $allIds)
+            ->pluck('hellofresh_ids')
+            ->flatMap(function (?string $ids): array {
+                if ($ids === null) {
+                    return [];
+                }
+
+                $decoded = json_decode($ids, true);
+
+                return is_array($decoded) ? $decoded : [];
+            })
+            ->unique()
+            ->values()
+            ->all();
+
+        // Update the keeper with merged IDs
+        DB::table('ingredients')
+            ->where('id', $keepId)
+            ->update(['hellofresh_ids' => json_encode($allHelloFreshIds)]);
+    }
+
+    /**
+     * Move pivot entries from duplicates to the keeper.
+     *
+     * @param  list<int>  $deleteIds
+     */
+    protected function movePivotEntries(int $keepId, array $deleteIds): int
+    {
+        // Get existing recipe_ids for the keeper to avoid duplicates
+        $existingRecipeIds = DB::table('ingredient_recipe')
+            ->where('ingredient_id', $keepId)
+            ->pluck('recipe_id')
+            ->all();
+
+        // Get unique recipe_ids from duplicates that don't exist in keeper
+        $newRecipeIds = DB::table('ingredient_recipe')
+            ->whereIn('ingredient_id', $deleteIds)
+            ->whereNotIn('recipe_id', $existingRecipeIds)
+            ->distinct()
+            ->pluck('recipe_id')
+            ->all();
+
+        // Delete ALL pivot entries from duplicates first
+        DB::table('ingredient_recipe')
+            ->whereIn('ingredient_id', $deleteIds)
+            ->delete();
+
+        // Insert new unique entries for the keeper
+        $insertData = array_map(fn (int $recipeId): array => [
+            'ingredient_id' => $keepId,
+            'recipe_id' => $recipeId,
+        ], $newRecipeIds);
+
+        if ($insertData !== []) {
+            DB::table('ingredient_recipe')->insert($insertData);
+        }
+
+        return count($newRecipeIds);
+    }
+
+    /**
+     * Remove duplicate pivot entries for the keeper.
+     */
+    protected function removeDuplicatePivots(int $keepId): int
+    {
+        // Find duplicate recipe_ids for this ingredient
+        $duplicatePivots = DB::table('ingredient_recipe')
+            ->select('recipe_id', DB::raw('COUNT(*) as count'), DB::raw('MIN(id) as keep_pivot_id'))
+            ->where('ingredient_id', $keepId)
+            ->groupBy('recipe_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        $removed = 0;
+        foreach ($duplicatePivots as $duplicatePivot) {
+            $removed += DB::table('ingredient_recipe')
+                ->where('ingredient_id', $keepId)
+                ->where('recipe_id', $duplicatePivot->recipe_id)
+                ->where('id', '!=', $duplicatePivot->keep_pivot_id)
+                ->delete();
+        }
+
+        return $removed;
+    }
+}

--- a/tests/Unit/Support/Markdown/FluxRendererTest.php
+++ b/tests/Unit/Support/Markdown/FluxRendererTest.php
@@ -45,7 +45,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('# Heading 1');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:heading size="xl" level="1">Heading 1</flux:heading>', (string) $output);
+        $this->assertStringContainsString('<flux:heading size="xl" level="1">Heading 1</flux:heading>', $output);
     }
 
     #[Test]
@@ -54,7 +54,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('## Heading 2');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:heading size="lg" level="2">Heading 2</flux:heading>', (string) $output);
+        $this->assertStringContainsString('<flux:heading size="lg" level="2">Heading 2</flux:heading>', $output);
     }
 
     #[Test]
@@ -63,7 +63,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('### Heading 3');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:heading size="base" level="3">Heading 3</flux:heading>', (string) $output);
+        $this->assertStringContainsString('<flux:heading size="base" level="3">Heading 3</flux:heading>', $output);
     }
 
     #[Test]
@@ -72,7 +72,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('#### Heading 4');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:heading size="base" level="4">Heading 4</flux:heading>', (string) $output);
+        $this->assertStringContainsString('<flux:heading size="base" level="4">Heading 4</flux:heading>', $output);
     }
 
     #[Test]
@@ -81,7 +81,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('This is a paragraph.');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:text>This is a paragraph.</flux:text>', (string) $output);
+        $this->assertStringContainsString('<flux:text>This is a paragraph.</flux:text>', $output);
     }
 
     #[Test]
@@ -90,7 +90,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('This is **bold** text.');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<strong>bold</strong>', (string) $output);
+        $this->assertStringContainsString('<strong>bold</strong>', $output);
     }
 
     #[Test]
@@ -99,7 +99,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('This is *italic* text.');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<em>italic</em>', (string) $output);
+        $this->assertStringContainsString('<em>italic</em>', $output);
     }
 
     #[Test]
@@ -110,8 +110,8 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('[Link](/path/to/page)');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:link href="/path/to/page">Link</flux:link>', (string) $output);
-        $this->assertStringNotContainsString('external', (string) $output);
+        $this->assertStringContainsString('<flux:link href="/path/to/page">Link</flux:link>', $output);
+        $this->assertStringNotContainsString('external', $output);
     }
 
     #[Test]
@@ -122,7 +122,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('[External](https://other.com/page)');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:link href="https://other.com/page" external>External</flux:link>', (string) $output);
+        $this->assertStringContainsString('<flux:link href="https://other.com/page" external>External</flux:link>', $output);
     }
 
     #[Test]
@@ -131,8 +131,8 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('[Anchor](#section)');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:link href="#section">Anchor</flux:link>', (string) $output);
-        $this->assertStringNotContainsString('external', (string) $output);
+        $this->assertStringContainsString('<flux:link href="#section">Anchor</flux:link>', $output);
+        $this->assertStringNotContainsString('external', $output);
     }
 
     #[Test]
@@ -141,8 +141,8 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('[Email](mailto:test@example.com)');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:link href="mailto:test@example.com">Email</flux:link>', (string) $output);
-        $this->assertStringNotContainsString('external', (string) $output);
+        $this->assertStringContainsString('<flux:link href="mailto:test@example.com">Email</flux:link>', $output);
+        $this->assertStringNotContainsString('external', $output);
     }
 
     #[Test]
@@ -151,9 +151,9 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse("- Item 1\n- Item 2");
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<ul class="ml-6 list-disc space-y-2">', (string) $output);
-        $this->assertStringContainsString('<li class="text-zinc-600 dark:text-zinc-400">Item 1</li>', (string) $output);
-        $this->assertStringContainsString('<li class="text-zinc-600 dark:text-zinc-400">Item 2</li>', (string) $output);
+        $this->assertStringContainsString('<ul class="ml-6 list-disc space-y-2">', $output);
+        $this->assertStringContainsString('<li class="text-zinc-600 dark:text-zinc-400">Item 1</li>', $output);
+        $this->assertStringContainsString('<li class="text-zinc-600 dark:text-zinc-400">Item 2</li>', $output);
     }
 
     #[Test]
@@ -162,8 +162,8 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse("1. First\n2. Second");
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<ol class="ml-6 list-disc space-y-2">', (string) $output);
-        $this->assertStringContainsString('<li class="text-zinc-600 dark:text-zinc-400">First</li>', (string) $output);
+        $this->assertStringContainsString('<ol class="ml-6 list-disc space-y-2">', $output);
+        $this->assertStringContainsString('<li class="text-zinc-600 dark:text-zinc-400">First</li>', $output);
     }
 
     #[Test]
@@ -172,7 +172,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse("Above\n\n---\n\nBelow");
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:separator />', (string) $output);
+        $this->assertStringContainsString('<flux:separator />', $output);
     }
 
     #[Test]
@@ -181,7 +181,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('Use `inline code` here.');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<code class="rounded bg-zinc-100 px-1.5 py-0.5 text-sm dark:bg-zinc-800">inline code</code>', (string) $output);
+        $this->assertStringContainsString('<code class="rounded bg-zinc-100 px-1.5 py-0.5 text-sm dark:bg-zinc-800">inline code</code>', $output);
     }
 
     #[Test]
@@ -190,8 +190,8 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse("```php\necho 'Hello';\n```");
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<pre class="overflow-x-auto rounded-lg bg-zinc-100 p-4 dark:bg-zinc-800"><code>', (string) $output);
-        $this->assertStringContainsString('echo &#039;Hello&#039;;', (string) $output);
+        $this->assertStringContainsString('<pre class="overflow-x-auto rounded-lg bg-zinc-100 p-4 dark:bg-zinc-800"><code>', $output);
+        $this->assertStringContainsString('echo &#039;Hello&#039;;', $output);
     }
 
     #[Test]
@@ -200,8 +200,8 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('    indented code');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<pre class="overflow-x-auto rounded-lg bg-zinc-100 p-4 dark:bg-zinc-800"><code>', (string) $output);
-        $this->assertStringContainsString('indented code', (string) $output);
+        $this->assertStringContainsString('<pre class="overflow-x-auto rounded-lg bg-zinc-100 p-4 dark:bg-zinc-800"><code>', $output);
+        $this->assertStringContainsString('indented code', $output);
     }
 
     #[Test]
@@ -210,9 +210,9 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('> This is a quote');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:callout>', (string) $output);
-        $this->assertStringContainsString('This is a quote', (string) $output);
-        $this->assertStringContainsString('</flux:callout>', (string) $output);
+        $this->assertStringContainsString('<flux:callout>', $output);
+        $this->assertStringContainsString('This is a quote', $output);
+        $this->assertStringContainsString('</flux:callout>', $output);
     }
 
     #[Test]
@@ -222,11 +222,11 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse($markdown);
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:table>', (string) $output);
-        $this->assertStringContainsString('<flux:table.columns>', (string) $output);
-        $this->assertStringContainsString('<flux:table.column>Header 1</flux:table.column>', (string) $output);
-        $this->assertStringContainsString('<flux:table.rows>', (string) $output);
-        $this->assertStringContainsString('<flux:table.cell>Cell 1</flux:table.cell>', (string) $output);
+        $this->assertStringContainsString('<flux:table>', $output);
+        $this->assertStringContainsString('<flux:table.columns>', $output);
+        $this->assertStringContainsString('<flux:table.column>Header 1</flux:table.column>', $output);
+        $this->assertStringContainsString('<flux:table.rows>', $output);
+        $this->assertStringContainsString('<flux:table.cell>Cell 1</flux:table.cell>', $output);
     }
 
     #[Test]
@@ -236,7 +236,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse($markdown);
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:table.column>Header</flux:table.column>', (string) $output);
+        $this->assertStringContainsString('<flux:table.column>Header</flux:table.column>', $output);
     }
 
     #[Test]
@@ -246,7 +246,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse($markdown);
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<flux:table.cell>Cell</flux:table.cell>', (string) $output);
+        $this->assertStringContainsString('<flux:table.cell>Cell</flux:table.cell>', $output);
     }
 
     #[Test]
@@ -255,7 +255,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse("Line 1  \nLine 2");
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<br />', (string) $output);
+        $this->assertStringContainsString('<br />', $output);
     }
 
     #[Test]
@@ -264,7 +264,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse("Line 1\nLine 2");
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('Line 1 Line 2', (string) $output);
+        $this->assertStringContainsString('Line 1 Line 2', $output);
     }
 
     #[Test]
@@ -273,7 +273,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse("<div>Custom HTML</div>\n\n");
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<div>Custom HTML</div>', (string) $output);
+        $this->assertStringContainsString('<div>Custom HTML</div>', $output);
     }
 
     #[Test]
@@ -282,7 +282,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('Text with <span>inline HTML</span> here.');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<span>inline HTML</span>', (string) $output);
+        $this->assertStringContainsString('<span>inline HTML</span>', $output);
     }
 
     #[Test]
@@ -291,9 +291,9 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('Text with special chars: & < >');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('&amp;', (string) $output);
-        $this->assertStringContainsString('&lt;', (string) $output);
-        $this->assertStringContainsString('&gt;', (string) $output);
+        $this->assertStringContainsString('&amp;', $output);
+        $this->assertStringContainsString('&lt;', $output);
+        $this->assertStringContainsString('&gt;', $output);
     }
 
     #[Test]
@@ -302,7 +302,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('[Link](https://example.com/path?foo=bar&baz=qux)');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('href="https://example.com/path?foo=bar&amp;baz=qux"', (string) $output);
+        $this->assertStringContainsString('href="https://example.com/path?foo=bar&amp;baz=qux"', $output);
     }
 
     #[Test]
@@ -311,7 +311,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse("```\n<script>alert('xss')</script>\n```");
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('&lt;script&gt;', (string) $output);
+        $this->assertStringContainsString('&lt;script&gt;', $output);
     }
 
     #[Test]
@@ -329,8 +329,8 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('This is ***bold and italic*** text.');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<strong>', (string) $output);
-        $this->assertStringContainsString('<em>', (string) $output);
+        $this->assertStringContainsString('<strong>', $output);
+        $this->assertStringContainsString('<em>', $output);
     }
 
     #[Test]
@@ -342,7 +342,7 @@ final class FluxRendererTest extends TestCase
         $output = $this->fluxRenderer->render($document);
 
         // Relative URLs without leading slash are treated as external by parse_url
-        $this->assertStringContainsString('href="relative/path"', (string) $output);
+        $this->assertStringContainsString('href="relative/path"', $output);
     }
 
     #[Test]
@@ -353,7 +353,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('[Link](https://example.com/page)');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringNotContainsString('external', (string) $output);
+        $this->assertStringNotContainsString('external', $output);
     }
 
     #[Test]
@@ -362,7 +362,7 @@ final class FluxRendererTest extends TestCase
         $document = $this->parse('- Item with **bold** and *italic*');
         $output = $this->fluxRenderer->render($document);
 
-        $this->assertStringContainsString('<li class="text-zinc-600 dark:text-zinc-400">Item with <strong>bold</strong> and <em>italic</em></li>', (string) $output);
+        $this->assertStringContainsString('<li class="text-zinc-600 dark:text-zinc-400">Item with <strong>bold</strong> and <em>italic</em></li>', $output);
     }
 
     #[Test]
@@ -372,6 +372,6 @@ final class FluxRendererTest extends TestCase
         $output = $this->fluxRenderer->render($document);
 
         // URLs without a host should not be marked external
-        $this->assertStringNotContainsString(' external', (string) $output);
+        $this->assertStringNotContainsString(' external', $output);
     }
 }


### PR DESCRIPTION
…ntry_id

- Implements `data-maintenance:merge-duplicate-ingredients` command
- Supports `--dry-run` to display changes without applying them
- Handles duplicate group merging, pivot entries, and cleanup operations