### PR TITLE
feat: add Sentry logging driver and update default `LOG_STACK` channel

### DIFF
--- a/config/logging.php
+++ b/config/logging.php
@@ -54,8 +54,12 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'daily')),
             'ignore_exceptions' => false,
+        ],
+
+        'sentry' => [
+            'driver' => 'sentry',
         ],
 
         'single' => [

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -69,7 +69,7 @@ return [
     | @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#traces-sample-rate
     |
     */
-    'traces_sample_rate' => env('SENTRY_TRACES_SAMPLE_RATE') === null ? null :
+    'traces_sample_rate' => env('SENTRY_TRACES_SAMPLE_RATE') === null ? 0 :
         (float) env('SENTRY_TRACES_SAMPLE_RATE'),
 
     /*


### PR DESCRIPTION
- Introduce Sentry driver configuration for enhanced error monitoring
- Change default `LOG_STACK` channel from `single` to `daily`