### PR TITLE
fix: sanitize inline styles in recipe steps to improve dark mode comp…

### DIFF
--- a/app/Livewire/Recipes/RecipeShow.php
+++ b/app/Livewire/Recipes/RecipeShow.php
@@ -134,7 +134,18 @@ class RecipeShow extends AbstractComponent
         /** @var array<int|string, array<string, mixed>>|null $steps */
         $steps = $this->recipe->steps_primary;
 
-        return $steps !== null ? array_values($steps) : [];
+        if ($steps === null) {
+            return [];
+        }
+
+        return array_values(array_map(function (array $step): array {
+            if (isset($step['instructions']) && is_string($step['instructions'])) {
+                // Remove inline styles that break dark mode
+                $step['instructions'] = preg_replace('/\s*style="[^"]*"/i', '', $step['instructions']);
+            }
+
+            return $step;
+        }, $steps));
     }
 
     /**

--- a/resources/views/livewire/recipes/recipe-show.blade.php
+++ b/resources/views/livewire/recipes/recipe-show.blade.php
@@ -206,9 +206,9 @@
                 @endforeach
               </div>
             @endif
-            <div class="prose prose-sm dark:prose-invert max-w-none">
+            <flux:text>
               {!! $step['instructions'] !!}
-            </div>
+            </flux:text>
           </div>
         </div>
       @endforeach


### PR DESCRIPTION
…atibility

- Strip `style` attributes from step instructions to avoid breaking dark mode
- Replace `div.prose` with `flux:text` for consistent markup