### PR TITLE
feat: improve API handling and retry logic in FetchMenusJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [3.2.0] - 2025-12-24
+## [3.2.0] - 2025-12-25
 
 ### Added
 

--- a/app/Jobs/Concerns/HandlesApiFailuresTrait.php
+++ b/app/Jobs/Concerns/HandlesApiFailuresTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Jobs\Concerns;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Log;
+
+trait HandlesApiFailuresTrait
+{
+    /**
+     * Handle a failed API request with logging and retry logic.
+     *
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    protected function handleApiFailure(ConnectionException|RequestException $exception): void
+    {
+        $isLastAttempt = $this->attempts() >= $this->tries;
+
+        if ($isLastAttempt) {
+            throw $exception;
+        }
+
+        Log::warning(static::class . ' failed, retrying', [
+            'attempt' => $this->attempts(),
+            'exception' => $exception->getMessage(),
+        ]);
+
+        $this->release(30);
+    }
+}

--- a/app/Jobs/SyncRecipesJob.php
+++ b/app/Jobs/SyncRecipesJob.php
@@ -8,7 +8,6 @@ use App\Models\Country;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Log;
 use Throwable;
 
 /**
@@ -44,7 +43,6 @@ class SyncRecipesJob implements LauncherJobInterface, ShouldQueue
      */
     public function handle(): void
     {
-        Log::debug('Syncing HelloFresh recipes...');
         $countries = Country::orderBy('id')->get();
 
         $primaryJobs = [];

--- a/composer.json
+++ b/composer.json
@@ -83,10 +83,6 @@
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
         ],
-        "dev": [
-            "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"pnpm run dev\" --names=server,queue,logs,vite"
-        ],
         "ide-helper": [
             "@php artisan ide-helper:models --nowrite --ansi",
             "@php artisan ide-helper:generate --ansi",


### PR DESCRIPTION
- Add HandlesApiFailuresTrait to manage API failure scenarios
- Increase job retry limit from 2 to 3
- Enhance error handling with try-catch for connection exceptions and failed API responses
- Prevent job execution on API failures via early return mechanisms