### PR TITLE
feat: update recipe route to use slug and Hellofresh ID, enhance parameter validation

### DIFF
--- a/resources/views/components/recipes/recipe-card.blade.php
+++ b/resources/views/components/recipes/recipe-card.blade.php
@@ -57,7 +57,9 @@
 
         <div class="p-4">
             <flux:heading size="lg" class="line-clamp-1">
-                <flux:link :href="localized_route('localized.recipes.show', ['recipe' => $recipe])">{{ $recipe->name }}</flux:link>
+                <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->hellofresh_id])">
+                  {{ $recipe->name }}
+                </flux:link>
             </flux:heading>
 
             @if ($recipe->headline)
@@ -108,7 +110,9 @@
         <div class="flex flex-1 flex-col justify-center py-2">
             <div class="flex items-center gap-2">
                 <flux:heading size="lg" class="line-clamp-1">
-                    <flux:link :href="localized_route('localized.recipes.show', ['recipe' => $recipe])">{{ $recipe->name }}</flux:link>
+                    <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->hellofresh_id])">
+                      {{ $recipe->name }}
+                    </flux:link>
                 </flux:heading>
                 @if ($recipe->label && $recipe->label->display_label)
                     <span

--- a/resources/views/livewire/recipes/recipe-show.blade.php
+++ b/resources/views/livewire/recipes/recipe-show.blade.php
@@ -247,7 +247,9 @@
             @endif
             <div class="p-4">
               <flux:heading size="sm" class="line-clamp-2">
-                <flux:link :href="localized_route('localized.recipes.show', ['recipe' => $similarRecipe])">{{ $similarRecipe->name }}</flux:link>
+                <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($similarRecipe->name), 'recipe' => $similarRecipe->hellofresh_id])">
+                  {{ $similarRecipe->name }}
+                </flux:link>
               </flux:heading>
             </div>
           </flux:card>

--- a/resources/views/livewire/shopping-list/shopping-list-index.blade.php
+++ b/resources/views/livewire/shopping-list/shopping-list-index.blade.php
@@ -298,7 +298,7 @@
                 @endif
 
                 <div class="flex-1">
-                  <flux:link :href="localized_route('localized.recipes.show', ['recipe' => $recipe])" wire:navigate class="print:hidden">
+                  <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->hellofresh_id])" wire:navigate class="print:hidden">
                     {{ $recipe->name }}
                   </flux:link>
                   <flux:heading size="sm" class="not-print:hidden">{{ $recipe->name }}</flux:heading>

--- a/resources/views/livewire/user/user-recipe-lists.blade.php
+++ b/resources/views/livewire/user/user-recipe-lists.blade.php
@@ -123,7 +123,9 @@
 
               <div class="p-4">
                 <flux:heading size="lg" class="line-clamp-1">
-                  <flux:link :href="localized_route('localized.recipes.show', ['recipe' => $recipe])">{{ $recipe->name }}</flux:link>
+                  <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->hellofresh_id])">
+                    {{ $recipe->name }}
+                  </flux:link>
                 </flux:heading>
 
                 @if ($recipe->headline)

--- a/routes/web-localized.php
+++ b/routes/web-localized.php
@@ -13,8 +13,8 @@ use App\Livewire\User\UserShoppingLists;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', RecipeIndex::class)->name('recipes.index');
-Route::get('recipes/{recipe}', RecipeShow::class)
-    ->where('recipe', '[0-9]+')
+Route::get('recipes/{slug}-{recipe:hellofresh_id}', RecipeShow::class)
+    ->where(['slug' => '.*', 'recipe' => '[a-f0-9]{24}'])
     ->name('recipes.show');
 Route::get('shopping-list', ShoppingListIndex::class)->name('shopping-list.index');
 Route::get('shopping-list/print', ShoppingListIndex::class)->name('shopping-list.print');

--- a/support/helpers.php
+++ b/support/helpers.php
@@ -72,3 +72,13 @@ if (! function_exists('page_title')) {
         return implode($separator, $crumbs);
     }
 }
+
+if (! function_exists('slugify')) {
+    /**
+     * Generate a URL friendly 'slug' from a given string.
+     */
+    function slugify(string $title): string
+    {
+        return Str::slug($title, language: app()->getLocale());
+    }
+}

--- a/tests/Unit/SlugifyTest.php
+++ b/tests/Unit/SlugifyTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class SlugifyTest extends TestCase
+{
+    #[DataProvider('slugifyDataProvider')]
+    public function test_slugify_generates_correct_slug(string $locale, string $input, string $expected): void
+    {
+        app()->setLocale($locale);
+
+        $this->assertSame($expected, slugify($input));
+    }
+
+    /**
+     * @return array<string, array{locale: string, input: string, expected: string}>
+     */
+    public static function slugifyDataProvider(): array
+    {
+        return [
+            'german with umlauts' => [
+                'locale' => 'de',
+                'input' => 'Würstchen mit Käse',
+                'expected' => 'wuerstchen-mit-kaese',
+            ],
+            'danish with special characters' => [
+                'locale' => 'da',
+                'input' => 'Blødkogt æg med rødkål',
+                'expected' => 'bloedkogt-aeg-med-roedkaal',
+            ],
+            'swedish with special characters' => [
+                'locale' => 'sv',
+                'input' => 'Köttbullar med gräddsås',
+                'expected' => 'kottbullar-med-graddsas',
+            ],
+            'norwegian with special characters' => [
+                'locale' => 'nb',
+                'input' => 'Blåbær på fjellet',
+                'expected' => 'blabaer-pa-fjellet',
+            ],
+            'dutch with special characters' => [
+                'locale' => 'nl',
+                'input' => 'Gëorganiseerd café',
+                'expected' => 'georganiseerd-cafe',
+            ],
+            'french with accents' => [
+                'locale' => 'fr',
+                'input' => 'Crème brûlée à la française',
+                'expected' => 'creme-brulee-a-la-francaise',
+            ],
+            'spanish with special characters' => [
+                'locale' => 'es',
+                'input' => 'Paella española con mariscos',
+                'expected' => 'paella-espanola-con-mariscos',
+            ],
+            'italian with accents' => [
+                'locale' => 'it',
+                'input' => 'Caffè con biscotti',
+                'expected' => 'caffe-con-biscotti',
+            ],
+            'english simple' => [
+                'locale' => 'en',
+                'input' => 'Fish and chips',
+                'expected' => 'fish-and-chips',
+            ],
+            'removes multiple spaces' => [
+                'locale' => 'en',
+                'input' => 'Hello    World',
+                'expected' => 'hello-world',
+            ],
+            'removes special characters' => [
+                'locale' => 'en',
+                'input' => 'Hello! World#',
+                'expected' => 'hello-world',
+            ],
+            'converts at symbol' => [
+                'locale' => 'en',
+                'input' => 'Hello @World',
+                'expected' => 'hello-at-world',
+            ],
+            'handles empty string' => [
+                'locale' => 'en',
+                'input' => '',
+                'expected' => '',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
- Replace numeric `recipe` parameter with `{slug}-{recipe:hellofresh_id}` format
- Add validation for hexadecimal `recipe` ID and flexible `slug` wildcard