### PR TITLE
feat: implement sitemap generation and serving functionality

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Country;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+class SitemapController extends Controller
+{
+    /**
+     * Serve the sitemap index listing all country/locale sitemaps.
+     */
+    public function index(): Response
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+        $xml .= '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+
+        $countries = Country::query()
+            ->active()
+            ->orderBy('code')
+            ->get(['code', 'locales', 'updated_at']);
+
+        foreach ($countries as $country) {
+            foreach ($country->locales as $locale) {
+                $filename = sprintf('sitemap-%s-%s.xml', $locale, $country->code);
+
+                if (! Storage::disk('public')->exists('sitemaps/' . $filename)) {
+                    continue;
+                }
+
+                $lastMod = Storage::disk('public')->lastModified('sitemaps/' . $filename);
+
+                $xml .= sprintf(
+                    "  <sitemap>\n    <loc>%s</loc>\n    <lastmod>%s</lastmod>\n  </sitemap>\n",
+                    url(sprintf('sitemap/%s-%s.xml', $locale, $country->code)),
+                    Date::createFromTimestamp($lastMod)->format('Y-m-d')
+                );
+            }
+        }
+
+        $xml .= '</sitemapindex>';
+
+        return response($xml, SymfonyResponse::HTTP_OK, [
+            'Content-Type' => 'application/xml',
+            'Cache-Control' => 'public, max-age=3600',
+        ]);
+    }
+
+    /**
+     * Serve an individual sitemap for a locale/country combination.
+     */
+    public function show(string $locale, string $country): Response
+    {
+        $filename = sprintf('sitemap-%s-%s.xml', $locale, $country);
+
+        abort_unless(Storage::disk('public')->exists('sitemaps/' . $filename), SymfonyResponse::HTTP_NOT_FOUND);
+
+        $content = Storage::disk('public')->get('sitemaps/' . $filename);
+
+        return response($content, SymfonyResponse::HTTP_OK, [
+            'Content-Type' => 'application/xml',
+            'Cache-Control' => 'public, max-age=3600',
+        ]);
+    }
+}

--- a/app/Jobs/GenerateSitemapJob.php
+++ b/app/Jobs/GenerateSitemapJob.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Enums\QueueEnum;
+use App\Models\Country;
+use App\Models\Recipe;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+/**
+ * @method static void dispatch(Country $country, string $locale)
+ */
+class GenerateSitemapJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public int $tries = 3;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     */
+    public int $timeout = 600;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Country $country,
+        public string $locale,
+    ) {
+        $this->onQueue(QueueEnum::Long->value);
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        // Set locale for proper slug generation
+        app()->setLocale($this->locale);
+
+        $xml = $this->buildSitemapXml();
+        $filename = $this->getSitemapFilename();
+
+        Storage::disk('public')->put('sitemaps/' . $filename, $xml);
+    }
+
+    /**
+     * Build the sitemap XML content.
+     */
+    protected function buildSitemapXml(): string
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+        $xml .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+
+        // Add homepage
+        $xml .= $this->buildUrlEntry(
+            localized_route('localized.recipes.index', [], true, $this->country, $this->locale),
+            now()->toDateString(),
+            'daily',
+            '1.0'
+        );
+
+        // Add recipes in chunks to avoid memory issues
+        Recipe::where('country_id', $this->country->id)
+            ->select(['id', 'hellofresh_id', 'name', 'updated_at'])
+            ->orderBy('id')
+            ->chunk(1000, function (Collection $recipes) use (&$xml): void {
+                foreach ($recipes as $recipe) {
+                    $name = $recipe->getTranslation('name', $this->locale, useFallbackLocale: false)
+                        ?: $recipe->getFirstTranslation('name');
+
+                    if ($name === null) {
+                        continue;
+                    }
+
+                    $slug = Str::slug($name, language: $this->locale);
+                    $url = localized_route(
+                        'localized.recipes.show',
+                        ['slug' => $slug, 'recipe' => $recipe->hellofresh_id],
+                        true,
+                        $this->country,
+                        $this->locale
+                    );
+
+                    $xml .= $this->buildUrlEntry(
+                        $url,
+                        $recipe->updated_at?->toDateString() ?? now()->toDateString(),
+                        'monthly',
+                        '0.8'
+                    );
+                }
+            });
+
+        $xml .= '</urlset>';
+
+        return $xml;
+    }
+
+    /**
+     * Build a single URL entry for the sitemap.
+     */
+    protected function buildUrlEntry(string $loc, string $lastmod, string $changefreq, string $priority): string
+    {
+        return sprintf(
+            "  <url>\n    <loc>%s</loc>\n    <lastmod>%s</lastmod>\n    <changefreq>%s</changefreq>\n    <priority>%s</priority>\n  </url>\n",
+            htmlspecialchars($loc, ENT_XML1, 'UTF-8'),
+            $lastmod,
+            $changefreq,
+            $priority
+        );
+    }
+
+    /**
+     * Get the sitemap filename for this country/locale combination.
+     */
+    protected function getSitemapFilename(): string
+    {
+        return sprintf('sitemap-%s-%s.xml', $this->locale, $this->country->code);
+    }
+}

--- a/app/Jobs/GenerateSitemapsJob.php
+++ b/app/Jobs/GenerateSitemapsJob.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Contracts\LauncherJobInterface;
+use App\Enums\QueueEnum;
+use App\Models\Country;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @method static void dispatch()
+ */
+class GenerateSitemapsJob implements LauncherJobInterface, ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        $this->onQueue(QueueEnum::Long->value);
+    }
+
+    /**
+     * The console command description.
+     */
+    public static function description(): string
+    {
+        return 'Generate sitemaps for all active countries and locales';
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->ensureSitemapDirectoryExists();
+
+        $countries = Country::query()
+            ->active()
+            ->orderBy('code')
+            ->get();
+
+        foreach ($countries as $country) {
+            foreach ($country->locales as $locale) {
+                GenerateSitemapJob::dispatch($country, $locale);
+            }
+        }
+    }
+
+    /**
+     * Ensure the sitemaps directory exists.
+     */
+    protected function ensureSitemapDirectoryExists(): void
+    {
+        if (! Storage::disk('public')->exists('sitemaps')) {
+            Storage::disk('public')->makeDirectory('sitemaps');
+        }
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Jobs\GenerateSitemapsJob;
 use App\Jobs\SyncMenusJob;
 use App\Jobs\SyncRecipesJob;
 use App\Jobs\UpdateCountryStatisticsJob;
@@ -30,3 +31,6 @@ Schedule::job(new SyncMenusJob())
 
 Schedule::job(new UpdateCountryStatisticsJob())
     ->twiceDaily(4, 16);
+
+Schedule::job(new GenerateSitemapsJob())
+    ->dailyAt(12);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,11 +1,18 @@
 <?php
 
 use App\Http\Controllers\OgImageController;
+use App\Http\Controllers\SitemapController;
 use App\Livewire\Actions\LogoutAction;
 use App\Livewire\RegionSelect;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', RegionSelect::class)->name('region.select');
+
+// Sitemap routes
+Route::get('sitemap.xml', [SitemapController::class, 'index'])->name('sitemap.index');
+Route::get('sitemap/{locale}-{country}.xml', [SitemapController::class, 'show'])
+    ->where(['locale' => '[a-z]{2}', 'country' => '[A-Z]{2}'])
+    ->name('sitemap.show');
 
 Route::post('logout', LogoutAction::class)
     ->middleware('auth')

--- a/tests/Unit/SlugifyTest.php
+++ b/tests/Unit/SlugifyTest.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Tests\Unit;
 
+use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
-class SlugifyTest extends TestCase
+final class SlugifyTest extends TestCase
 {
     #[DataProvider('slugifyDataProvider')]
     public function test_slugify_generates_correct_slug(string $locale, string $input, string $expected): void
@@ -16,76 +19,74 @@ class SlugifyTest extends TestCase
     }
 
     /**
-     * @return array<string, array{locale: string, input: string, expected: string}>
+     * @return Iterator<string, array{locale: string, input: string, expected: string}>
      */
-    public static function slugifyDataProvider(): array
+    public static function slugifyDataProvider(): Iterator
     {
-        return [
-            'german with umlauts' => [
-                'locale' => 'de',
-                'input' => 'Würstchen mit Käse',
-                'expected' => 'wuerstchen-mit-kaese',
-            ],
-            'danish with special characters' => [
-                'locale' => 'da',
-                'input' => 'Blødkogt æg med rødkål',
-                'expected' => 'bloedkogt-aeg-med-roedkaal',
-            ],
-            'swedish with special characters' => [
-                'locale' => 'sv',
-                'input' => 'Köttbullar med gräddsås',
-                'expected' => 'kottbullar-med-graddsas',
-            ],
-            'norwegian with special characters' => [
-                'locale' => 'nb',
-                'input' => 'Blåbær på fjellet',
-                'expected' => 'blabaer-pa-fjellet',
-            ],
-            'dutch with special characters' => [
-                'locale' => 'nl',
-                'input' => 'Gëorganiseerd café',
-                'expected' => 'georganiseerd-cafe',
-            ],
-            'french with accents' => [
-                'locale' => 'fr',
-                'input' => 'Crème brûlée à la française',
-                'expected' => 'creme-brulee-a-la-francaise',
-            ],
-            'spanish with special characters' => [
-                'locale' => 'es',
-                'input' => 'Paella española con mariscos',
-                'expected' => 'paella-espanola-con-mariscos',
-            ],
-            'italian with accents' => [
-                'locale' => 'it',
-                'input' => 'Caffè con biscotti',
-                'expected' => 'caffe-con-biscotti',
-            ],
-            'english simple' => [
-                'locale' => 'en',
-                'input' => 'Fish and chips',
-                'expected' => 'fish-and-chips',
-            ],
-            'removes multiple spaces' => [
-                'locale' => 'en',
-                'input' => 'Hello    World',
-                'expected' => 'hello-world',
-            ],
-            'removes special characters' => [
-                'locale' => 'en',
-                'input' => 'Hello! World#',
-                'expected' => 'hello-world',
-            ],
-            'converts at symbol' => [
-                'locale' => 'en',
-                'input' => 'Hello @World',
-                'expected' => 'hello-at-world',
-            ],
-            'handles empty string' => [
-                'locale' => 'en',
-                'input' => '',
-                'expected' => '',
-            ],
+        yield 'german with umlauts' => [
+            'locale' => 'de',
+            'input' => 'Würstchen mit Käse',
+            'expected' => 'wuerstchen-mit-kaese',
+        ];
+        yield 'danish with special characters' => [
+            'locale' => 'da',
+            'input' => 'Blødkogt æg med rødkål',
+            'expected' => 'bloedkogt-aeg-med-roedkaal',
+        ];
+        yield 'swedish with special characters' => [
+            'locale' => 'sv',
+            'input' => 'Köttbullar med gräddsås',
+            'expected' => 'kottbullar-med-graddsas',
+        ];
+        yield 'norwegian with special characters' => [
+            'locale' => 'nb',
+            'input' => 'Blåbær på fjellet',
+            'expected' => 'blabaer-pa-fjellet',
+        ];
+        yield 'dutch with special characters' => [
+            'locale' => 'nl',
+            'input' => 'Gëorganiseerd café',
+            'expected' => 'georganiseerd-cafe',
+        ];
+        yield 'french with accents' => [
+            'locale' => 'fr',
+            'input' => 'Crème brûlée à la française',
+            'expected' => 'creme-brulee-a-la-francaise',
+        ];
+        yield 'spanish with special characters' => [
+            'locale' => 'es',
+            'input' => 'Paella española con mariscos',
+            'expected' => 'paella-espanola-con-mariscos',
+        ];
+        yield 'italian with accents' => [
+            'locale' => 'it',
+            'input' => 'Caffè con biscotti',
+            'expected' => 'caffe-con-biscotti',
+        ];
+        yield 'english simple' => [
+            'locale' => 'en',
+            'input' => 'Fish and chips',
+            'expected' => 'fish-and-chips',
+        ];
+        yield 'removes multiple spaces' => [
+            'locale' => 'en',
+            'input' => 'Hello    World',
+            'expected' => 'hello-world',
+        ];
+        yield 'removes special characters' => [
+            'locale' => 'en',
+            'input' => 'Hello! World#',
+            'expected' => 'hello-world',
+        ];
+        yield 'converts at symbol' => [
+            'locale' => 'en',
+            'input' => 'Hello @World',
+            'expected' => 'hello-at-world',
+        ];
+        yield 'handles empty string' => [
+            'locale' => 'en',
+            'input' => '',
+            'expected' => '',
         ];
     }
 }


### PR DESCRIPTION
- Add `GenerateSitemapsJob` and `GenerateSitemapJob` to handle sitemap creation for countries and locales
- Introduce `SitemapController` to serve sitemaps and sitemap index
- Register sitemap routes in `web.php`
- Schedule daily sitemap generation via `console.php`
- Refactor `SlugifyTest` to use `Iterator` for data providers and enforce stricter typing