### PR TITLE
refactor: update region-select lang attribute to include country code

### DIFF
--- a/resources/views/livewire/region-select.blade.php
+++ b/resources/views/livewire/region-select.blade.php
@@ -21,7 +21,7 @@
               :href="localized_route('localized.recipes.index', country: $country, locale: $locale)"
               variant="primary"
               size="sm"
-              :lang="$locale"
+              :lang="$locale . '-' . $country->code"
               wire:navigate
             >
               {{ __('language.' . $locale, [], $locale) }}


### PR DESCRIPTION
- Modify `:lang` binding to append country code for improved locale-specific handling