### PR TITLE
refactor: extract recipe filter options into reusable trait and updat…

### DIFF
--- a/app/Livewire/Recipes/Concerns/WithRecipeFilterOptionsTrait.php
+++ b/app/Livewire/Recipes/Concerns/WithRecipeFilterOptionsTrait.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Recipes\Concerns;
+
+use App\Models\Allergen;
+use App\Models\Ingredient;
+use App\Models\Label;
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
+
+/**
+ * Provides computed properties for recipe filter options.
+ *
+ * @property int $countryId
+ * @property array<int> $ingredientIds
+ * @property array<int> $excludedIngredientIds
+ * @property string $ingredientSearch
+ * @property string $excludedIngredientSearch
+ */
+trait WithRecipeFilterOptionsTrait
+{
+    /**
+     * Get available allergens for the current country.
+     *
+     * @return Collection<int, Allergen>
+     */
+    #[Computed]
+    public function allergens(): Collection
+    {
+        return Allergen::where('country_id', $this->countryId)
+            ->active()
+            ->orderBy('name')
+            ->get();
+    }
+
+    /**
+     * Get available tags for the current country.
+     *
+     * @return Collection<int, Tag>
+     */
+    #[Computed]
+    public function tags(): Collection
+    {
+        return Tag::where('country_id', $this->countryId)
+            ->active()
+            ->orderBy('name')
+            ->get();
+    }
+
+    /**
+     * Get available labels for the current country.
+     *
+     * @return Collection<int, Label>
+     */
+    #[Computed]
+    public function labels(): Collection
+    {
+        return Label::where('country_id', $this->countryId)
+            ->active()
+            ->orderBy('name')
+            ->get();
+    }
+
+    /**
+     * Search ingredients for the current country.
+     *
+     * @return Collection<int, Ingredient>
+     */
+    #[Computed]
+    public function ingredientResults(): Collection
+    {
+        if ($this->ingredientSearch === '') {
+            return new Collection();
+        }
+
+        return Ingredient::where('country_id', $this->countryId)
+            ->active()
+            ->whereLike('name', sprintf('%%%s%%', $this->ingredientSearch))
+            ->whereNotIn('id', $this->ingredientIds)
+            ->orderBy('name')
+            ->limit(20)
+            ->get();
+    }
+
+    /**
+     * Get selected ingredients.
+     *
+     * @return Collection<int, Ingredient>
+     */
+    #[Computed]
+    public function selectedIngredients(): Collection
+    {
+        if ($this->ingredientIds === []) {
+            return new Collection();
+        }
+
+        return Ingredient::whereIn('id', $this->ingredientIds)->get();
+    }
+
+    /**
+     * Search ingredients to exclude for the current country.
+     *
+     * @return Collection<int, Ingredient>
+     */
+    #[Computed]
+    public function excludedIngredientResults(): Collection
+    {
+        if ($this->excludedIngredientSearch === '') {
+            return new Collection();
+        }
+
+        return Ingredient::where('country_id', $this->countryId)
+            ->active()
+            ->whereLike('name', sprintf('%%%s%%', $this->excludedIngredientSearch))
+            ->whereNotIn('id', $this->excludedIngredientIds)
+            ->orderBy('name')
+            ->limit(20)
+            ->get();
+    }
+
+    /**
+     * Get selected excluded ingredients.
+     *
+     * @return Collection<int, Ingredient>
+     */
+    #[Computed]
+    public function selectedExcludedIngredients(): Collection
+    {
+        if ($this->excludedIngredientIds === []) {
+            return new Collection();
+        }
+
+        return Ingredient::whereIn('id', $this->excludedIngredientIds)->get();
+    }
+}

--- a/app/Livewire/Recipes/RecipeIndex.php
+++ b/app/Livewire/Recipes/RecipeIndex.php
@@ -7,17 +7,13 @@ use App\Enums\RecipeSortEnum;
 use App\Enums\ViewModeEnum;
 use App\Livewire\AbstractComponent;
 use App\Livewire\Concerns\WithLocalizedContextTrait;
-use App\Models\Allergen;
-use App\Models\Ingredient;
-use App\Models\Label;
+use App\Livewire\Recipes\Concerns\WithRecipeFilterOptionsTrait;
 use App\Models\Menu;
 use App\Models\Recipe;
-use App\Models\Tag;
 use Carbon\CarbonInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View as ViewInterface;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\WithPagination;
@@ -27,6 +23,7 @@ class RecipeIndex extends AbstractComponent
 {
     use WithLocalizedContextTrait;
     use WithPagination;
+    use WithRecipeFilterOptionsTrait;
 
     protected int $perPage = 12;
 
@@ -317,120 +314,6 @@ class RecipeIndex extends AbstractComponent
         }
 
         return $count;
-    }
-
-    /**
-     * Get available allergens for the current country.
-     *
-     * @return Collection<int, Allergen>
-     */
-    #[Computed]
-    public function allergens(): Collection
-    {
-        return Allergen::where('country_id', $this->countryId)
-            ->active()
-            ->orderBy('name')
-            ->get();
-    }
-
-    /**
-     * Get available tags for the current country.
-     *
-     * @return Collection<int, Tag>
-     */
-    #[Computed]
-    public function tags(): Collection
-    {
-        return Tag::where('country_id', $this->countryId)
-            ->active()
-            ->orderBy('name')
-            ->get();
-    }
-
-    /**
-     * Get available labels for the current country.
-     *
-     * @return Collection<int, Label>
-     */
-    #[Computed]
-    public function labels(): Collection
-    {
-        return Label::where('country_id', $this->countryId)
-            ->active()
-            ->orderBy('name')
-            ->get();
-    }
-
-    /**
-     * Search ingredients for the current country.
-     *
-     * @return Collection<int, Ingredient>
-     */
-    #[Computed]
-    public function ingredientResults(): Collection
-    {
-        if ($this->ingredientSearch === '') {
-            return new Collection();
-        }
-
-        return Ingredient::where('country_id', $this->countryId)
-            ->active()
-            ->whereLike('name', sprintf('%%%s%%', $this->ingredientSearch))
-            ->whereNotIn('id', $this->ingredientIds)
-            ->orderBy('name')
-            ->limit(20)
-            ->get();
-    }
-
-    /**
-     * Get selected ingredients.
-     *
-     * @return Collection<int, Ingredient>
-     */
-    #[Computed]
-    public function selectedIngredients(): Collection
-    {
-        if ($this->ingredientIds === []) {
-            return new Collection();
-        }
-
-        return Ingredient::whereIn('id', $this->ingredientIds)->get();
-    }
-
-    /**
-     * Search ingredients to exclude for the current country.
-     *
-     * @return Collection<int, Ingredient>
-     */
-    #[Computed]
-    public function excludedIngredientResults(): Collection
-    {
-        if ($this->excludedIngredientSearch === '') {
-            return new Collection();
-        }
-
-        return Ingredient::where('country_id', $this->countryId)
-            ->active()
-            ->whereLike('name', sprintf('%%%s%%', $this->excludedIngredientSearch))
-            ->whereNotIn('id', $this->excludedIngredientIds)
-            ->orderBy('name')
-            ->limit(20)
-            ->get();
-    }
-
-    /**
-     * Get selected excluded ingredients.
-     *
-     * @return Collection<int, Ingredient>
-     */
-    #[Computed]
-    public function selectedExcludedIngredients(): Collection
-    {
-        if ($this->excludedIngredientIds === []) {
-            return new Collection();
-        }
-
-        return Ingredient::whereIn('id', $this->excludedIngredientIds)->get();
     }
 
     /**

--- a/tests/Feature/Livewire/GlobalSearchTest.php
+++ b/tests/Feature/Livewire/GlobalSearchTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\GlobalSearch;
+use App\Models\Country;
+use App\Models\Menu;
+use App\Models\Recipe;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Override;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalSearchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Country $country;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->country = Country::factory()->create([
+            'code' => 'US',
+            'locales' => ['en'],
+        ]);
+
+        app()->bind('current.country', fn (): Country => $this->country);
+        app()->setLocale('en');
+    }
+
+    #[Test]
+    public function it_can_render(): void
+    {
+        Livewire::test(GlobalSearch::class)
+            ->assertStatus(200);
+    }
+
+    #[Test]
+    public function it_shows_type_to_search_when_empty(): void
+    {
+        Livewire::test(GlobalSearch::class)
+            ->assertSee(__('Type to search...'));
+    }
+
+    #[Test]
+    public function it_shows_no_results_found_when_search_has_no_matches(): void
+    {
+        Livewire::test(GlobalSearch::class)
+            ->set('search', 'nonexistentrecipename12345')
+            ->assertSee(__('No results found.'));
+    }
+
+    #[Test]
+    public function it_finds_recipes_by_name(): void
+    {
+        Recipe::factory()->for($this->country)->create([
+            'name' => ['en' => 'Delicious Pasta Carbonara'],
+        ]);
+
+        Livewire::test(GlobalSearch::class)
+            ->set('search', 'Pasta')
+            ->assertSee('Delicious Pasta Carbonara');
+    }
+
+    #[Test]
+    public function it_finds_recipes_by_headline(): void
+    {
+        Recipe::factory()->for($this->country)->create([
+            'name' => ['en' => 'Simple Dish'],
+            'headline' => ['en' => 'With creamy mushroom sauce'],
+        ]);
+
+        Livewire::test(GlobalSearch::class)
+            ->set('search', 'mushroom')
+            ->assertSee('Simple Dish');
+    }
+
+    #[Test]
+    public function it_only_finds_recipes_for_current_country(): void
+    {
+        $otherCountry = Country::factory()->create(['code' => 'DE']);
+
+        Recipe::factory()->for($this->country)->create([
+            'name' => ['en' => 'American Recipe'],
+        ]);
+        Recipe::factory()->for($otherCountry)->create([
+            'name' => ['en' => 'German Recipe'],
+        ]);
+
+        Livewire::test(GlobalSearch::class)
+            ->set('search', 'Recipe')
+            ->assertSee('American Recipe')
+            ->assertDontSee('German Recipe');
+    }
+
+    #[Test]
+    public function it_shows_menus_for_recipes(): void
+    {
+        $recipe = Recipe::factory()->for($this->country)->create([
+            'name' => ['en' => 'Weekly Special'],
+        ]);
+
+        $menu = Menu::factory()->for($this->country)->create([
+            'year_week' => 202501,
+        ]);
+        $menu->recipes()->attach($recipe);
+
+        Livewire::test(GlobalSearch::class)
+            ->set('search', 'Weekly')
+            ->assertSee('Weekly Special')
+            ->assertSee(__('Week') . ' 01');
+    }
+
+    #[Test]
+    public function it_limits_results_to_ten_recipes(): void
+    {
+        Recipe::factory()->for($this->country)->count(15)->create([
+            'name' => ['en' => 'Test Recipe'],
+        ]);
+
+        $component = Livewire::test(GlobalSearch::class)
+            ->set('search', 'Test');
+
+        $this->assertCount(10, $component->instance()->recipes);
+    }
+
+    #[Test]
+    public function it_can_navigate_to_recipe(): void
+    {
+        $recipe = Recipe::factory()->for($this->country)->create([
+            'name' => ['en' => 'Navigable Recipe'],
+            'hellofresh_id' => 'abc123',
+        ]);
+
+        Livewire::test(GlobalSearch::class)
+            ->call('selectRecipe', $recipe->id)
+            ->assertRedirect();
+    }
+}

--- a/tests/Unit/Http/Middleware/CountryMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/CountryMiddlewareTest.php
@@ -93,10 +93,10 @@ final class CountryMiddlewareTest extends TestCase
     {
         $this->expectException(NotFoundHttpException::class);
 
-        $request = Request::create('/xx/en');
-        $route = new Route('GET', '/{country}/{locale}', fn (): string => 'OK');
+        $request = Request::create('/en-XX');
+        $route = new Route('GET', '/{locale}-{country}', fn (): string => 'OK');
         $route->bind($request);
-        $route->setParameter('country', 'xx');
+        $route->setParameter('country', 'XX');
         $route->setParameter('locale', 'en');
 
         $request->setRouteResolver(fn (): Route => $route);
@@ -110,7 +110,7 @@ final class CountryMiddlewareTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
 
         Country::factory()->create([
-            'code' => 'us',
+            'code' => 'US',
             'locales' => ['en'],
             'active' => true,
             'prep_min' => 5,
@@ -118,10 +118,10 @@ final class CountryMiddlewareTest extends TestCase
             'ingredients_count' => 50,
         ]);
 
-        $request = Request::create('/us/de');
-        $route = new Route('GET', '/{country}/{locale}', fn (): string => 'OK');
+        $request = Request::create('/de-US');
+        $route = new Route('GET', '/{locale}-{country}', fn (): string => 'OK');
         $route->bind($request);
-        $route->setParameter('country', 'us');
+        $route->setParameter('country', 'US');
         $route->setParameter('locale', 'de');
 
         $request->setRouteResolver(fn (): Route => $route);
@@ -135,14 +135,14 @@ final class CountryMiddlewareTest extends TestCase
         $this->expectException(NotFoundHttpException::class);
 
         Country::factory()->inactive()->create([
-            'code' => 'us',
+            'code' => 'US',
             'locales' => ['en'],
         ]);
 
-        $request = Request::create('/us/en');
-        $route = new Route('GET', '/{country}/{locale}', fn (): string => 'OK');
+        $request = Request::create('/en-US');
+        $route = new Route('GET', '/{locale}-{country}', fn (): string => 'OK');
         $route->bind($request);
-        $route->setParameter('country', 'us');
+        $route->setParameter('country', 'US');
         $route->setParameter('locale', 'en');
 
         $request->setRouteResolver(fn (): Route => $route);
@@ -154,7 +154,7 @@ final class CountryMiddlewareTest extends TestCase
     public function it_sets_app_locale(): void
     {
         Country::factory()->create([
-            'code' => 'de',
+            'code' => 'DE',
             'locales' => ['de', 'en'],
             'active' => true,
             'prep_min' => 5,
@@ -162,10 +162,10 @@ final class CountryMiddlewareTest extends TestCase
             'ingredients_count' => 50,
         ]);
 
-        $request = Request::create('/de/de');
-        $route = new Route('GET', '/{country}/{locale}', fn (): string => 'OK');
+        $request = Request::create('/de-DE');
+        $route = new Route('GET', '/{locale}-{country}', fn (): string => 'OK');
         $route->bind($request);
-        $route->setParameter('country', 'de');
+        $route->setParameter('country', 'DE');
         $route->setParameter('locale', 'de');
 
         $request->setRouteResolver(fn (): Route => $route);
@@ -179,7 +179,7 @@ final class CountryMiddlewareTest extends TestCase
     public function it_sets_fallback_locale(): void
     {
         Country::factory()->create([
-            'code' => 'ch',
+            'code' => 'CH',
             'locales' => ['de', 'fr', 'it'],
             'active' => true,
             'prep_min' => 5,
@@ -187,10 +187,10 @@ final class CountryMiddlewareTest extends TestCase
             'ingredients_count' => 50,
         ]);
 
-        $request = Request::create('/ch/de');
-        $route = new Route('GET', '/{country}/{locale}', fn (): string => 'OK');
+        $request = Request::create('/de-CH');
+        $route = new Route('GET', '/{locale}-{country}', fn (): string => 'OK');
         $route->bind($request);
-        $route->setParameter('country', 'ch');
+        $route->setParameter('country', 'CH');
         $route->setParameter('locale', 'de');
 
         $request->setRouteResolver(fn (): Route => $route);
@@ -204,7 +204,7 @@ final class CountryMiddlewareTest extends TestCase
     public function it_sets_fallback_locale_to_en_when_no_other_locales(): void
     {
         Country::factory()->create([
-            'code' => 'us',
+            'code' => 'US',
             'locales' => ['en'],
             'active' => true,
             'prep_min' => 5,
@@ -212,10 +212,10 @@ final class CountryMiddlewareTest extends TestCase
             'ingredients_count' => 50,
         ]);
 
-        $request = Request::create('/us/en');
-        $route = new Route('GET', '/{country}/{locale}', fn (): string => 'OK');
+        $request = Request::create('/en-US');
+        $route = new Route('GET', '/{locale}-{country}', fn (): string => 'OK');
         $route->bind($request);
-        $route->setParameter('country', 'us');
+        $route->setParameter('country', 'US');
         $route->setParameter('locale', 'en');
 
         $request->setRouteResolver(fn (): Route => $route);
@@ -229,7 +229,7 @@ final class CountryMiddlewareTest extends TestCase
     public function it_binds_country_to_container(): void
     {
         $country = Country::factory()->create([
-            'code' => 'us',
+            'code' => 'US',
             'locales' => ['en'],
             'active' => true,
             'prep_min' => 5,
@@ -237,10 +237,10 @@ final class CountryMiddlewareTest extends TestCase
             'ingredients_count' => 50,
         ]);
 
-        $request = Request::create('/us/en');
-        $route = new Route('GET', '/{country}/{locale}', fn (): string => 'OK');
+        $request = Request::create('/en-US');
+        $route = new Route('GET', '/{locale}-{country}', fn (): string => 'OK');
         $route->bind($request);
-        $route->setParameter('country', 'us');
+        $route->setParameter('country', 'US');
         $route->setParameter('locale', 'en');
 
         $request->setRouteResolver(fn (): Route => $route);
@@ -255,7 +255,7 @@ final class CountryMiddlewareTest extends TestCase
     public function it_forgets_locale_and_country_parameters(): void
     {
         Country::factory()->create([
-            'code' => 'us',
+            'code' => 'US',
             'locales' => ['en'],
             'active' => true,
             'prep_min' => 5,
@@ -263,10 +263,10 @@ final class CountryMiddlewareTest extends TestCase
             'ingredients_count' => 50,
         ]);
 
-        $request = Request::create('/us/en');
-        $route = new Route('GET', '/{country}/{locale}', fn (): string => 'OK');
+        $request = Request::create('/en-US');
+        $route = new Route('GET', '/{locale}-{country}', fn (): string => 'OK');
         $route->bind($request);
-        $route->setParameter('country', 'us');
+        $route->setParameter('country', 'US');
         $route->setParameter('locale', 'en');
 
         $request->setRouteResolver(fn (): Route => $route);

--- a/tests/Unit/Jobs/FetchMenusJobTest.php
+++ b/tests/Unit/Jobs/FetchMenusJobTest.php
@@ -45,7 +45,7 @@ final class FetchMenusJobTest extends TestCase
         $country = Country::factory()->create();
         $job = new FetchMenusJob($country);
 
-        $this->assertSame(2, $job->tries);
+        $this->assertSame(3, $job->tries);
     }
 
     #[Test]
@@ -65,6 +65,7 @@ final class FetchMenusJobTest extends TestCase
         ]);
 
         $client = Mockery::mock(HelloFreshClient::class);
+        $client->shouldReceive('withOutThrow')->andReturnSelf();
         $client->shouldReceive('getMenus')
             ->times(8)
             ->andReturn($this->createMenusResponse([]));
@@ -103,6 +104,7 @@ final class FetchMenusJobTest extends TestCase
         ];
 
         $client = Mockery::mock(HelloFreshClient::class);
+        $client->shouldReceive('withOutThrow')->andReturnSelf();
         $client->shouldReceive('getMenus')
             ->times(8)
             ->andReturn($this->createMenusResponse($menuData));
@@ -144,6 +146,7 @@ final class FetchMenusJobTest extends TestCase
         ];
 
         $client = Mockery::mock(HelloFreshClient::class);
+        $client->shouldReceive('withOutThrow')->andReturnSelf();
         $client->shouldReceive('getMenus')
             ->times(8)
             ->andReturn($this->createMenusResponse($menuData));
@@ -165,6 +168,7 @@ final class FetchMenusJobTest extends TestCase
         ]);
 
         $client = Mockery::mock(HelloFreshClient::class);
+        $client->shouldReceive('withOutThrow')->andReturnSelf();
         $client->shouldReceive('getMenus')
             ->withArgs(function ($countryArg, $locale): bool {
                 return $locale === 'de';
@@ -186,6 +190,7 @@ final class FetchMenusJobTest extends TestCase
         ]);
 
         $client = Mockery::mock(HelloFreshClient::class);
+        $client->shouldReceive('withOutThrow')->andReturnSelf();
         $client->shouldReceive('getMenus')
             ->withArgs(function ($countryArg, $locale): bool {
                 return $locale === 'en';

--- a/tests/Unit/Jobs/ImportRecipeJobTest.php
+++ b/tests/Unit/Jobs/ImportRecipeJobTest.php
@@ -380,7 +380,7 @@ final class ImportRecipeJobTest extends TestCase
             ->whereJsonContains('handles', 'premium')
             ->first();
 
-        $this->assertInstanceOf(stdClass::class, $label);
+        $this->assertInstanceOf(Label::class, $label);
         $this->assertTrue($label->display_label);
     }
 
@@ -401,7 +401,7 @@ final class ImportRecipeJobTest extends TestCase
 
         $label = Label::whereJsonContains('handles', 'premium')->first();
 
-        $this->assertInstanceOf(stdClass::class, $label);
+        $this->assertInstanceOf(Label::class, $label);
     }
 
     #[Test]


### PR DESCRIPTION
…e tests

- Create `WithRecipeFilterOptionsTrait` for centralized filter management
- Refactor `RecipeIndex` to use the new trait, reducing duplication
- Add corresponding feature tests for `GlobalSearch`
- Adjust test cases to reflect changes in filter logic and request routing