### PR TITLE
refactor: improve `WithLocalizedContextTrait` and middleware tests

### DIFF
--- a/tests/Feature/Http/Middleware/AuthenticateOrShowMessageMiddlewareTest.php
+++ b/tests/Feature/Http/Middleware/AuthenticateOrShowMessageMiddlewareTest.php
@@ -6,39 +6,35 @@ namespace Tests\Feature\Http\Middleware;
 
 use App\Models\Country;
 use App\Models\User;
+use Iterator;
 use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 final class AuthenticateOrShowMessageMiddlewareTest extends TestCase
 {
-    private Country $country;
-
     #[Override]
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->country = Country::factory()->create([
+        $country = Country::factory()->create([
             'code' => 'US',
             'locales' => ['en'],
         ]);
 
-        app()->bind('current.country', fn (): Country => $this->country);
+        app()->bind('current.country', fn (): Country => $country);
     }
 
     /**
-     * @return array<string, array{string}>
+     * @return Iterator<string, array{string}>
      */
-    public static function protectedRoutesProvider(): array
+    public static function protectedRoutesProvider(): Iterator
     {
-        return [
-            'settings' => ['localized.settings'],
-            'lists' => ['localized.lists'],
-            'saved-shopping-lists' => ['localized.saved-shopping-lists'],
-        ];
+        yield 'settings' => ['localized.settings'];
+        yield 'lists' => ['localized.lists'];
+        yield 'saved-shopping-lists' => ['localized.saved-shopping-lists'];
     }
 
     #[Test]
@@ -47,7 +43,7 @@ final class AuthenticateOrShowMessageMiddlewareTest extends TestCase
     {
         $response = $this->get(localized_route($routeName));
 
-        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+        $response->assertUnauthorized();
         $response->assertViewIs('auth.require-login');
     }
 
@@ -67,7 +63,7 @@ final class AuthenticateOrShowMessageMiddlewareTest extends TestCase
     {
         $response = $this->get(localized_route('localized.settings'));
 
-        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+        $response->assertUnauthorized();
         $response->assertSee(__('Login Required'));
         $response->assertSee(__('Please log in to access this page.'));
     }

--- a/tests/Unit/Livewire/Concerns/WithLocalizedContextTraitTest.php
+++ b/tests/Unit/Livewire/Concerns/WithLocalizedContextTraitTest.php
@@ -62,17 +62,17 @@ final class WithLocalizedContextTraitTest extends TestCase
     }
 
     #[Test]
-    public function it_restores_context_on_subsequent_requests(): void
+    public function it_restores_context_on_hydrate(): void
     {
         // First request sets up the context
         $component = Livewire::test(TestComponent::class);
 
-        // Clear the binding to simulate a new request
+        // Clear the binding to simulate a new Livewire request
         app()->forgetInstance('current.country');
 
-        // Simulate subsequent Livewire request by calling boot again
+        // Simulate subsequent Livewire request by calling hydrate
         $instance = $component->instance();
-        $instance->bootWithLocalizedContextTrait();
+        $instance->hydrateWithLocalizedContextTrait();
 
         // Verify the context was restored
         $this->assertTrue(app()->bound('current.country'));
@@ -87,7 +87,7 @@ final class WithLocalizedContextTraitTest extends TestCase
         $instance = $component->instance();
 
         // This should not throw and should keep existing binding
-        $instance->bootWithLocalizedContextTrait();
+        $instance->hydrateWithLocalizedContextTrait();
 
         $this->assertTrue(app()->bound('current.country'));
     }


### PR DESCRIPTION
- Simplify initialization and hydration logic in `WithLocalizedContextTrait` by renaming methods and removing redundant properties
- Update Livewire trait tests to reflect method changes
- Use `Iterator` instead of `array` in `protectedRoutesProvider` for cleaner data handling in middleware tests
- Replace deprecated `assertStatus` calls with `assertUnauthorized` in middleware test assertions