### PR TITLE
refactor: remove unused fields from API resources and documentation

### DIFF
--- a/app/Http/Resources/Api/AllergenResource.php
+++ b/app/Http/Resources/Api/AllergenResource.php
@@ -27,7 +27,6 @@ class AllergenResource extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->getTranslationWithAnyFallback('name', ContentLocale::get()),
-            'icon_path' => $this->icon_path,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Http/Resources/Api/IngredientResource.php
+++ b/app/Http/Resources/Api/IngredientResource.php
@@ -27,7 +27,6 @@ class IngredientResource extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->getTranslationWithAnyFallback('name', ContentLocale::get()),
-            'image_path' => $this->image_path,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Http/Resources/Api/LabelResource.php
+++ b/app/Http/Resources/Api/LabelResource.php
@@ -27,8 +27,6 @@ class LabelResource extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->getTranslationWithAnyFallback('name', ContentLocale::get()),
-            'foreground_color' => $this->foreground_color,
-            'background_color' => $this->background_color,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Http/Resources/Api/RecipeCollectionResource.php
+++ b/app/Http/Resources/Api/RecipeCollectionResource.php
@@ -34,7 +34,6 @@ class RecipeCollectionResource extends JsonResource
             'difficulty' => $this->difficulty,
             'prep_time' => $this->prep_time,
             'total_time' => $this->total_time,
-            'image_url' => $this->card_image_url,
             'has_pdf' => $this->has_pdf,
             'label' => new LabelResource($this->whenLoaded('label')),
             'tags' => TagResource::collection($this->whenLoaded('tags')),

--- a/app/Livewire/Portal/Docs/AllergensDoc.php
+++ b/app/Livewire/Portal/Docs/AllergensDoc.php
@@ -40,7 +40,6 @@ class AllergensDoc extends AbstractEndpointDoc
         return [
             ['name' => 'id', 'type' => 'integer', 'description' => 'Allergen ID'],
             ['name' => 'name', 'type' => 'string', 'description' => 'Allergen name (localized)'],
-            ['name' => 'icon_path', 'type' => 'string', 'description' => 'Path to allergen icon'],
             ['name' => 'created_at', 'type' => 'datetime', 'description' => 'Creation timestamp'],
             ['name' => 'updated_at', 'type' => 'datetime', 'description' => 'Last update timestamp'],
         ];

--- a/app/Livewire/Portal/Docs/IngredientsDoc.php
+++ b/app/Livewire/Portal/Docs/IngredientsDoc.php
@@ -42,7 +42,6 @@ class IngredientsDoc extends AbstractEndpointDoc
         return [
             ['name' => 'id', 'type' => 'integer', 'description' => 'Ingredient ID'],
             ['name' => 'name', 'type' => 'string', 'description' => 'Ingredient name (localized)'],
-            ['name' => 'image_path', 'type' => 'string', 'description' => 'Path to ingredient image'],
             ['name' => 'created_at', 'type' => 'datetime', 'description' => 'Creation timestamp'],
             ['name' => 'updated_at', 'type' => 'datetime', 'description' => 'Last update timestamp'],
         ];

--- a/app/Livewire/Portal/Docs/LabelsDoc.php
+++ b/app/Livewire/Portal/Docs/LabelsDoc.php
@@ -40,8 +40,6 @@ class LabelsDoc extends AbstractEndpointDoc
         return [
             ['name' => 'id', 'type' => 'integer', 'description' => 'Label ID'],
             ['name' => 'name', 'type' => 'string', 'description' => 'Label name (localized)'],
-            ['name' => 'foreground_color', 'type' => 'string', 'description' => 'Text color (hex format)'],
-            ['name' => 'background_color', 'type' => 'string', 'description' => 'Background color (hex format)'],
             ['name' => 'created_at', 'type' => 'datetime', 'description' => 'Creation timestamp'],
             ['name' => 'updated_at', 'type' => 'datetime', 'description' => 'Last update timestamp'],
         ];

--- a/app/Livewire/Portal/Docs/RecipesIndexDoc.php
+++ b/app/Livewire/Portal/Docs/RecipesIndexDoc.php
@@ -50,7 +50,6 @@ class RecipesIndexDoc extends AbstractEndpointDoc
             ['name' => 'difficulty', 'type' => 'integer', 'description' => 'Difficulty level (1-3)'],
             ['name' => 'prep_time', 'type' => 'integer', 'description' => 'Preparation time in minutes'],
             ['name' => 'total_time', 'type' => 'integer', 'description' => 'Total cooking time in minutes'],
-            ['name' => 'image_url', 'type' => 'string', 'description' => 'URL to recipe card image'],
             ['name' => 'has_pdf', 'type' => 'boolean', 'description' => 'Whether recipe has a PDF card'],
             ['name' => 'label', 'type' => 'object|null', 'description' => 'Recipe label'],
             ['name' => 'tags', 'type' => 'array', 'description' => 'Recipe tags'],


### PR DESCRIPTION
- Delete `foreground_color` and `background_color` from `LabelResource` and its documentation.
- Remove `image_url` from `RecipeCollectionResource` and `RecipesIndexDoc`.
- Omit `icon_path` and `image_path` fields from `AllergenResource`, `IngredientResource`, and their respective docs.