### PR TITLE
feat: add API portal settings and version display

### DIFF
--- a/config/api.php
+++ b/config/api.php
@@ -45,6 +45,30 @@ return [
         'per_page_min' => 10,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | API Portal Domain Name
+    |--------------------------------------------------------------------------
+    |
+    | This value specifies the domain name for the API Portal. The portal
+    | provides API documentation, token management, and authentication
+    | for API consumers on a dedicated subdomain.
+    |
+    */
+
     'portal_domain_name' => env('API_PORTAL_DOMAIN_NAME'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | API Version
+    |--------------------------------------------------------------------------
+    |
+    | This value represents the current version of the API. It is displayed
+    | in the API Portal footer and can be used to track API releases and
+    | communicate version information to API consumers.
+    |
+    */
+
+    'version' => env('API_VERSION', 'unknown'),
 
 ];

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "build": "vite build",
         "dev": "vite",
-        "dev:admin": "vite --config vite.config.portal.js"
+        "dev:portal": "vite --config vite.config.portal.js"
     },
     "dependencies": {
         "@tailwindcss/vite": "^4.1.17",

--- a/resources/views/portal/components/layouts/app.blade.php
+++ b/resources/views/portal/components/layouts/app.blade.php
@@ -107,6 +107,18 @@
     {{ $slot }}
 </flux:main>
 
+<flux:footer class="bg-zinc-50 dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-700 !py-3 text-sm flex justify-end gap-4">
+  <flux:text variant="subtle">
+    API Version: {{ config('api.version') }}
+  </flux:text>
+  <div>
+    {{ __('Made with') }} <span class="text-red-500">&hearts;</span> {{ __('by') }}
+    <flux:link href="https://huth.it" target="_blank" class="font-medium hover:text-zinc-700 dark:hover:text-zinc-200">
+      Norman Huth
+    </flux:link>
+  </div>
+</flux:footer>
+
 <flux:toast.group position="bottom end">
     <flux:toast />
 </flux:toast.group>


### PR DESCRIPTION
- Introduce `portal_domain_name` and `version` fields in API configuration.
- Update main layout footer to display current API version dynamically.
- Rename `dev:admin` script to `dev:portal` for clarity.