### PR TITLE
feat: implement API rate limiting and throttle middleware

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,13 +20,13 @@ return Application::configure(basePath: dirname(__DIR__))
             Route::middleware(['web'])
                 ->domain((string) parse_url((string) config('app.url'), PHP_URL_HOST))
                 ->group(base_path('routes/web.php'));
-            Route::middleware(['api'])
+            Route::middleware(['api', 'throttle:api'])
                 ->prefix(config('api.path'))
                 ->domain(config('api.domain_name'))
                 ->name('api.')
                 ->group(base_path('routes/api.php'));
 
-            Route::middleware(['api', 'auth:sanctum', ApiLocalizationMiddleware::class])
+            Route::middleware(['api', 'throttle:api', 'auth:sanctum', ApiLocalizationMiddleware::class])
                 ->domain(config('api.domain_name'))
                 ->prefix('{locale}-{country}')
                 ->name('api-localized.')

--- a/config/api.php
+++ b/config/api.php
@@ -47,6 +47,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | API Rate Limiting
+    |--------------------------------------------------------------------------
+    |
+    | This value defines the maximum number of API requests a user can make
+    | per minute. Rate limiting helps protect the API from abuse and ensures
+    | fair usage across all consumers.
+    |
+    */
+
+    'rate_limit' => env('API_RATE_LIMIT', 60),
+
+    /*
+    |--------------------------------------------------------------------------
     | API Portal Domain Name
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
- Add `rate_limit` configuration to `api.php` for defining API request limits per minute.
- Introduce `configureRateLimiting` method in `AppServiceProvider` to set up rate limiters.
- Update API route middleware to include `throttle:api` for enforcing rate limits.