### PR TITLE
feat: introduce API resource collections and migrate controllers

### DIFF
--- a/app/Http/Controllers/Api/CountryController.php
+++ b/app/Http/Controllers/Api/CountryController.php
@@ -3,19 +3,19 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\CountryCollection;
 use App\Models\Country;
 use Illuminate\Http\Request;
-use Illuminate\Pagination\LengthAwarePaginator;
 
 class CountryController extends Controller
 {
     /**
      * Display a listing of the resource.
-     *
-     * @return LengthAwarePaginator<array-key, Country>
      */
-    public function index(Request $request): LengthAwarePaginator
+    public function index(Request $request): CountryCollection
     {
-        return Country::active()->paginate(validated_per_page($request));
+        return new CountryCollection(
+            Country::active()->paginate(validated_per_page($request))
+        );
     }
 }

--- a/app/Http/Controllers/Api/Localized/IngredientController.php
+++ b/app/Http/Controllers/Api/Localized/IngredientController.php
@@ -2,20 +2,19 @@
 
 namespace App\Http\Controllers\Api\Localized;
 
-use App\Http\Resources\Api\IngredientResource;
+use App\Http\Resources\Api\IngredientCollection;
 use App\Models\Ingredient;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class IngredientController extends AbstractLocalizedController
 {
     /**
      * Display a listing of the resource.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index(Request $request): IngredientCollection
     {
-        return IngredientResource::collection(
+        return new IngredientCollection(
             Ingredient::where('country_id', $this->country()->id)
                 ->when($request->filled('search'), function (Builder $query) use ($request): void {
                     $query->whereLike('name', '%' . $request->string('search') . '%');

--- a/app/Http/Controllers/Api/Localized/MenuController.php
+++ b/app/Http/Controllers/Api/Localized/MenuController.php
@@ -2,36 +2,34 @@
 
 namespace App\Http\Controllers\Api\Localized;
 
+use App\Http\Resources\Api\MenuCollection;
 use App\Http\Resources\Api\MenuResource;
 use App\Models\Menu;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class MenuController extends AbstractLocalizedController
 {
     /**
      * Display a listing of the resource.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index(Request $request): MenuCollection
     {
-        $country = $this->country();
-
-        $menus = Menu::selectable()
-            ->where('country_id', $country->id)
-            ->when($request->boolean('include_recipes'), function (Builder $query): void {
-                $query->with(['recipes.label', 'recipes.tags']);
-            })
-            ->when($request->filled('from'), function (Builder $query) use ($request): void {
-                $query->where('start', '>=', $request->date('from'));
-            })
-            ->when($request->filled('to'), function (Builder $query) use ($request): void {
-                $query->where('start', '<=', $request->date('to'));
-            })
-            ->orderByDesc('year_week')
-            ->paginate(validated_per_page($request));
-
-        return MenuResource::collection($menus);
+        return new MenuCollection(
+            Menu::selectable()
+                ->where('country_id', $this->country()->id)
+                ->when($request->boolean('include_recipes'), function (Builder $query): void {
+                    $query->with(['recipes.label', 'recipes.tags']);
+                })
+                ->when($request->filled('from'), function (Builder $query) use ($request): void {
+                    $query->where('start', '>=', $request->date('from'));
+                })
+                ->when($request->filled('to'), function (Builder $query) use ($request): void {
+                    $query->where('start', '<=', $request->date('to'));
+                })
+                ->orderByDesc('year_week')
+                ->paginate(validated_per_page($request))
+        );
     }
 
     /**

--- a/app/Http/Controllers/Api/Localized/RecipeController.php
+++ b/app/Http/Controllers/Api/Localized/RecipeController.php
@@ -2,21 +2,23 @@
 
 namespace App\Http\Controllers\Api\Localized;
 
-use App\Http\Resources\Api\RecipeCollectionResource;
+use App\Http\Resources\Api\RecipeCollection;
 use App\Http\Resources\Api\RecipeResource;
 use App\Models\Recipe;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Throwable;
 
 class RecipeController extends AbstractLocalizedController
 {
     /**
      * Display a listing of the resource.
+     *
+     * @throws Throwable
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index(Request $request): RecipeCollection
     {
-        return RecipeCollectionResource::collection(
+        return new RecipeCollection(
             Recipe::where('country_id', $this->country()->id)
                 ->with(['label', 'tags'])
                 ->when($request->filled('search'), function (Builder $query) use ($request): void {

--- a/app/Http/Resources/Api/AbstractApiResourceCollection.php
+++ b/app/Http/Resources/Api/AbstractApiResourceCollection.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+abstract class AbstractApiResourceCollection extends ResourceCollection
+{
+    /**
+     * Customize the pagination information for the resource.
+     *
+     * @param  array<string, mixed>  $paginated
+     * @param  array<string, mixed>  $default
+     * @return array<string, mixed>
+     */
+    public function paginationInformation(Request $request, array $paginated, array $default): array
+    {
+        unset($default['links'], $default['meta']['links'], $default['meta']['path']);
+
+        return $default;
+    }
+}

--- a/app/Http/Resources/Api/CountryCollection.php
+++ b/app/Http/Resources/Api/CountryCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+/**
+ * @see \App\Models\Country
+ */
+class CountryCollection extends AbstractApiResourceCollection
+{
+    /**
+     * The resource that this resource collects.
+     *
+     * @var string
+     */
+    public $collects = CountryResource::class;
+}

--- a/app/Http/Resources/Api/CountryResource.php
+++ b/app/Http/Resources/Api/CountryResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+use App\Models\Country;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Override;
+
+/**
+ * @mixin Country
+ */
+class CountryResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'code' => $this->code,
+            'recipes_count' => $this->recipes_count,
+            'ingredients_count' => $this->ingredients_count,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Http/Resources/Api/IngredientCollection.php
+++ b/app/Http/Resources/Api/IngredientCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+/**
+ * @see \App\Models\Ingredient
+ */
+class IngredientCollection extends AbstractApiResourceCollection
+{
+    /**
+     * The resource that this resource collects.
+     *
+     * @var string
+     */
+    public $collects = IngredientResource::class;
+}

--- a/app/Http/Resources/Api/MenuCollection.php
+++ b/app/Http/Resources/Api/MenuCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+/**
+ * @see \App\Models\Menu
+ */
+class MenuCollection extends AbstractApiResourceCollection
+{
+    /**
+     * The resource that this resource collects.
+     *
+     * @var string
+     */
+    public $collects = MenuResource::class;
+}

--- a/app/Http/Resources/Api/RecipeCollection.php
+++ b/app/Http/Resources/Api/RecipeCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+/**
+ * @see \App\Models\Recipe
+ */
+class RecipeCollection extends AbstractApiResourceCollection
+{
+    /**
+     * The resource that this resource collects.
+     *
+     * @var string
+     */
+    public $collects = RecipeCollectionResource::class;
+}


### PR DESCRIPTION
- Add `AbstractApiResourceCollection` for shared collection functionality.
- Create `CountryCollection`, `IngredientCollection`, `MenuCollection`, and `RecipeCollection`.
- Replace `AnonymousResourceCollection` usage in controllers with new custom resource collections.
- Enhance pagination by customizing metadata in API responses.