### PR TITLE
feat: add "Get Started" API documentation and enhance resource collection functionality

### DIFF
--- a/app/Http/Controllers/Api/Localized/AllergenController.php
+++ b/app/Http/Controllers/Api/Localized/AllergenController.php
@@ -2,23 +2,22 @@
 
 namespace App\Http\Controllers\Api\Localized;
 
-use App\Http\Resources\Api\AllergenResource;
+use App\Http\Resources\Api\AllergenCollection;
 use App\Models\Allergen;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class AllergenController extends AbstractLocalizedController
 {
     /**
      * Display a listing of the resource.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index(Request $request): AllergenCollection
     {
-        return AllergenResource::collection(
+        return new AllergenCollection(
             Allergen::where('country_id', $this->country()->id)
                 ->tap(fn (Builder $query): Builder => $this->applySorting($query, $request))
-                ->get()
+                ->paginate(validated_per_page($request))
         );
     }
 }

--- a/app/Http/Controllers/Api/Localized/LabelController.php
+++ b/app/Http/Controllers/Api/Localized/LabelController.php
@@ -2,23 +2,22 @@
 
 namespace App\Http\Controllers\Api\Localized;
 
-use App\Http\Resources\Api\LabelResource;
+use App\Http\Resources\Api\LabelCollection;
 use App\Models\Label;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class LabelController extends AbstractLocalizedController
 {
     /**
      * Display a listing of the resource.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index(Request $request): LabelCollection
     {
-        return LabelResource::collection(
+        return new LabelCollection(
             Label::where('country_id', $this->country()->id)
                 ->tap(fn (Builder $query): Builder => $this->applySorting($query, $request))
-                ->get()
+                ->paginate(validated_per_page($request))
         );
     }
 }

--- a/app/Http/Controllers/Api/Localized/TagController.php
+++ b/app/Http/Controllers/Api/Localized/TagController.php
@@ -2,23 +2,22 @@
 
 namespace App\Http\Controllers\Api\Localized;
 
-use App\Http\Resources\Api\TagResource;
+use App\Http\Resources\Api\TagCollection;
 use App\Models\Tag;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class TagController extends AbstractLocalizedController
 {
     /**
      * Display a listing of the resource.
      */
-    public function index(Request $request): AnonymousResourceCollection
+    public function index(Request $request): TagCollection
     {
-        return TagResource::collection(
+        return new TagCollection(
             Tag::where('country_id', $this->country()->id)
                 ->tap(fn (Builder $query): Builder => $this->applySorting($query, $request))
-                ->get()
+                ->paginate(validated_per_page($request))
         );
     }
 }

--- a/app/Http/Resources/Api/AllergenCollection.php
+++ b/app/Http/Resources/Api/AllergenCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+/**
+ * @see \App\Models\Allergen
+ */
+class AllergenCollection extends AbstractApiResourceCollection
+{
+    /**
+     * The resource that this resource collects.
+     *
+     * @var string
+     */
+    public $collects = AllergenResource::class;
+}

--- a/app/Http/Resources/Api/LabelCollection.php
+++ b/app/Http/Resources/Api/LabelCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+/**
+ * @see \App\Models\Label
+ */
+class LabelCollection extends AbstractApiResourceCollection
+{
+    /**
+     * The resource that this resource collects.
+     *
+     * @var string
+     */
+    public $collects = LabelResource::class;
+}

--- a/app/Http/Resources/Api/TagCollection.php
+++ b/app/Http/Resources/Api/TagCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Resources\Api;
+
+/**
+ * @see \App\Models\Tag
+ */
+class TagCollection extends AbstractApiResourceCollection
+{
+    /**
+     * The resource that this resource collects.
+     *
+     * @var string
+     */
+    public $collects = TagResource::class;
+}

--- a/app/Livewire/Portal/Docs/AllergensDoc.php
+++ b/app/Livewire/Portal/Docs/AllergensDoc.php
@@ -31,6 +31,7 @@ class AllergensDoc extends AbstractEndpointDoc
     protected function queryParams(): array
     {
         return [
+            ['name' => 'per_page', 'type' => 'integer', 'description' => 'Results per page (' . config('api.pagination.per_page_min') . '-' . config('api.pagination.per_page_max') . ', default ' . config('api.pagination.per_page_default') . ')'],
             ['name' => 'sort', 'type' => 'string', 'description' => 'Sort by: created_at (default) or updated_at, always descending'],
         ];
     }

--- a/app/Livewire/Portal/Docs/GetStartedDoc.php
+++ b/app/Livewire/Portal/Docs/GetStartedDoc.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Livewire\Portal\Docs;
+
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('portal::components.layouts.app')]
+class GetStartedDoc extends Component
+{
+    public function render(): View
+    {
+        return view('portal::livewire.docs.get-started', [
+            'baseUrl' => 'https://' . config('api.domain_name'),
+            'rateLimit' => config('api.rate_limit'),
+            'paginationDefault' => config('api.pagination.per_page_default'),
+            'paginationMin' => config('api.pagination.per_page_min'),
+            'paginationMax' => config('api.pagination.per_page_max'),
+        ])->title('Get Started');
+    }
+}

--- a/app/Livewire/Portal/Docs/LabelsDoc.php
+++ b/app/Livewire/Portal/Docs/LabelsDoc.php
@@ -31,6 +31,7 @@ class LabelsDoc extends AbstractEndpointDoc
     protected function queryParams(): array
     {
         return [
+            ['name' => 'per_page', 'type' => 'integer', 'description' => 'Results per page (' . config('api.pagination.per_page_min') . '-' . config('api.pagination.per_page_max') . ', default ' . config('api.pagination.per_page_default') . ')'],
             ['name' => 'sort', 'type' => 'string', 'description' => 'Sort by: created_at (default) or updated_at, always descending'],
         ];
     }

--- a/app/Livewire/Portal/Docs/TagsDoc.php
+++ b/app/Livewire/Portal/Docs/TagsDoc.php
@@ -31,6 +31,7 @@ class TagsDoc extends AbstractEndpointDoc
     protected function queryParams(): array
     {
         return [
+            ['name' => 'per_page', 'type' => 'integer', 'description' => 'Results per page (' . config('api.pagination.per_page_min') . '-' . config('api.pagination.per_page_max') . ', default ' . config('api.pagination.per_page_default') . ')'],
             ['name' => 'sort', 'type' => 'string', 'description' => 'Sort by: created_at (default) or updated_at, always descending'],
         ];
     }

--- a/resources/views/portal/components/layouts/app.blade.php
+++ b/resources/views/portal/components/layouts/app.blade.php
@@ -26,6 +26,9 @@
         @endauth
 
         <flux:navlist.group expandable heading="API Reference" class="mt-4">
+            <flux:navlist.item href="{{ route('portal.docs.get-started') }}" :current="request()->routeIs('portal.docs.get-started')">
+                Get Started
+            </flux:navlist.item>
             <flux:navlist.item href="{{ route('portal.docs.countries') }}" :current="request()->routeIs('portal.docs.countries')">
                 Countries
             </flux:navlist.item>

--- a/resources/views/portal/livewire/docs/get-started.blade.php
+++ b/resources/views/portal/livewire/docs/get-started.blade.php
@@ -1,0 +1,95 @@
+<div class="space-y-section">
+    <div>
+        <flux:heading size="xl">Get Started</flux:heading>
+        <flux:text class="mt-ui">Everything you need to start using the {{ config('app.name') }} API.</flux:text>
+    </div>
+
+    <flux:card>
+        <flux:heading size="lg">Base URL</flux:heading>
+        <flux:text class="mt-ui">All API requests should be made to:</flux:text>
+        <pre class="mt-section p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>{{ $baseUrl }}</code></pre>
+    </flux:card>
+
+    <flux:card>
+        <flux:heading size="lg">Authentication</flux:heading>
+        <flux:text class="mt-ui">
+            The API uses Bearer token authentication. Include your API token in the <code class="text-sm bg-zinc-100 dark:bg-zinc-700 px-1 rounded">Authorization</code> header of every request.
+        </flux:text>
+        <pre class="mt-section p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>Authorization: Bearer YOUR_API_TOKEN</code></pre>
+        <flux:text class="mt-section text-sm">
+            @auth
+                You can manage your API tokens in the <flux:link href="{{ route('portal.tokens.index') }}">Token Management</flux:link> section.
+            @else
+                <flux:link href="{{ route('portal.login') }}">Sign in</flux:link> to create and manage your API tokens.
+            @endauth
+        </flux:text>
+    </flux:card>
+
+    <flux:card>
+        <flux:heading size="lg">Localization</flux:heading>
+        <flux:text class="mt-ui">
+            Most endpoints require a locale and country prefix in the URL path. This determines the language and region for the response data.
+        </flux:text>
+        <pre class="mt-section p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>GET {{ $baseUrl }}/{locale}-{country}/recipes</code></pre>
+        <flux:text class="mt-section text-sm">
+            Example: <code class="bg-zinc-100 dark:bg-zinc-700 px-1 rounded">de-DE</code> for German (Germany), <code class="bg-zinc-100 dark:bg-zinc-700 px-1 rounded">en-GB</code> for English (Great Britain).
+        </flux:text>
+        <flux:text class="mt-ui text-sm">
+            Use the <flux:link href="{{ route('portal.docs.countries') }}">Countries endpoint</flux:link> to get a list of available countries.
+        </flux:text>
+    </flux:card>
+
+    <flux:card>
+        <flux:heading size="lg">Rate Limiting</flux:heading>
+        <flux:text class="mt-ui">
+            API requests are limited to <strong>{{ $rateLimit }} requests per minute</strong> per user. If you exceed this limit, you will receive a <code class="text-sm bg-zinc-100 dark:bg-zinc-700 px-1 rounded">429 Too Many Requests</code> response.
+        </flux:text>
+        <flux:text class="mt-section text-sm">
+            Rate limit headers are included in every response:
+        </flux:text>
+        <pre class="mt-ui p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>X-RateLimit-Limit: {{ $rateLimit }}
+X-RateLimit-Remaining: {{ $rateLimit - 1 }}</code></pre>
+    </flux:card>
+
+    <flux:card>
+        <flux:heading size="lg">Pagination</flux:heading>
+        <flux:text class="mt-ui">
+            List endpoints return paginated results. Use the <code class="text-sm bg-zinc-100 dark:bg-zinc-700 px-1 rounded">per_page</code> query parameter to control the number of results ({{ $paginationMin }}-{{ $paginationMax }}, default {{ $paginationDefault }}).
+        </flux:text>
+        <pre class="mt-section p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>GET {{ $baseUrl }}/de-DE/recipes?per_page=25&page=2</code></pre>
+        <flux:text class="mt-section text-sm">
+            Paginated responses include a <code class="bg-zinc-100 dark:bg-zinc-700 px-1 rounded">meta</code> object with pagination information:
+        </flux:text>
+        <pre class="mt-ui p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>{
+    "data": [...],
+    "meta": {
+        "current_page": 2,
+        "from": 26,
+        "last_page": 10,
+        "per_page": 25,
+        "to": 50,
+        "total": 250
+    }
+}</code></pre>
+    </flux:card>
+
+    <flux:card>
+        <flux:heading size="lg">Response Format</flux:heading>
+        <flux:text class="mt-ui">
+            All responses are returned in JSON format. Include the <code class="text-sm bg-zinc-100 dark:bg-zinc-700 px-1 rounded">Accept: application/json</code> header in your requests.
+        </flux:text>
+        <flux:text class="mt-section text-sm">
+            Successful responses return HTTP status <code class="bg-zinc-100 dark:bg-zinc-700 px-1 rounded">200 OK</code>. Error responses include a message explaining what went wrong:
+        </flux:text>
+        <pre class="mt-ui p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>{
+    "message": "Unauthenticated."
+}</code></pre>
+    </flux:card>
+
+    <flux:card>
+        <flux:heading size="lg">Example Request</flux:heading>
+        <pre class="mt-section p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>curl -X GET "{{ $baseUrl }}/de-DE/recipes?per_page=10" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Accept: application/json"</code></pre>
+    </flux:card>
+</div>

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -6,6 +6,7 @@ use App\Livewire\Portal\Auth\VerifyEmail;
 use App\Livewire\Portal\Dashboard;
 use App\Livewire\Portal\Docs\AllergensDoc;
 use App\Livewire\Portal\Docs\CountriesDoc;
+use App\Livewire\Portal\Docs\GetStartedDoc;
 use App\Livewire\Portal\Docs\IngredientsDoc;
 use App\Livewire\Portal\Docs\LabelsDoc;
 use App\Livewire\Portal\Docs\MenusIndexDoc;
@@ -41,6 +42,7 @@ Route::get('/', Dashboard::class)->name('dashboard');
 
 // API Documentation (public, no authentication required)
 Route::prefix('docs')->name('docs.')->group(function (): void {
+    Route::get('/get-started', GetStartedDoc::class)->name('get-started');
     Route::get('/countries', CountriesDoc::class)->name('countries');
     Route::get('/recipes', RecipesIndexDoc::class)->name('recipes');
     Route::get('/recipes-show', RecipesShowDoc::class)->name('recipes-show');


### PR DESCRIPTION
- Introduce `GetStartedDoc` Livewire component and associated Blade view for API onboarding.
- Add `LabelCollection`, `TagCollection`, and `AllergenCollection` resources for improved response handling.
- Update controllers to use new resource collections with pagination support.
- Include `per_page` parameter across `TagsDoc`, `LabelsDoc`, and `AllergensDoc` for customizable pagination.
- Extend portal navigation with a "Get Started" link in the API Reference section.