### PR TITLE
feat: enhance API responses, documentation, and portal metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.5.0] - 2026-01-01
+
+### Added
+
+- **Public REST API** - Full-featured API for accessing recipe data programmatically
+    - Bearer token authentication via Laravel Sanctum
+    - Configurable rate limiting (default: 60 requests/minute)
+    - Localized endpoints (`/{locale}-{country}/...`)
+    - Unified pagination on all list endpoints
+- **API Portal** - Developer portal for API access
+    - Token management (create, view, revoke API tokens)
+    - Interactive API documentation
+    - Get Started guide with authentication, localization, and pagination info
+- **API Endpoints**
+    - Recipes (list, show with saved lists info for authenticated users)
+    - Menus (list, show with recipes)
+    - Ingredients, Countries, Tags, Labels, Allergens
+- **Response Enhancements**
+    - Website URLs in Recipe and Menu responses
+    - `saved_in_lists` field for authenticated users on Recipe show
+
 ## [3.4.0] - 2025-12-30
 
 ### Added

--- a/app/Http/Controllers/OgImageController.php
+++ b/app/Http/Controllers/OgImageController.php
@@ -88,6 +88,11 @@ class OgImageController extends Controller
     public function generic(Request $request): StreamedResponse
     {
         $title = $request->string('title', config('app.name'))->toString();
+        $font = $request->string('font')->toString();
+
+        if ($font === 'mono') {
+            $this->fontPath = resource_path('fonts/jet-brains-mono/ttf/JetBrainsMono-Medium.ttf');
+        }
 
         return $this->streamImage(function () use ($title): void {
             $canvas = $this->createCanvas();

--- a/app/Http/Resources/Api/MenuResource.php
+++ b/app/Http/Resources/Api/MenuResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources\Api;
 
 use App\Models\Menu;
+use App\Support\Api\ContentLocale;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Override;
@@ -20,8 +21,11 @@ class MenuResource extends JsonResource
     #[Override]
     public function toArray(Request $request): array
     {
+        $locale = ContentLocale::get();
+
         return [
             'id' => $this->id,
+            'url' => config('app.url') . '/' . $locale . '-' . resolve('current.country')->code . '/menus/' . $this->year_week,
             'year_week' => $this->year_week,
             'start' => $this->start->toDateString(),
             'recipes' => RecipeCollectionResource::collection($this->whenLoaded('recipes')),

--- a/app/Livewire/Portal/Docs/GetStartedDoc.php
+++ b/app/Livewire/Portal/Docs/GetStartedDoc.php
@@ -11,12 +11,16 @@ class GetStartedDoc extends Component
 {
     public function render(): View
     {
+        $version = config('api.version');
+
         return view('portal::livewire.docs.get-started', [
             'baseUrl' => 'https://' . config('api.domain_name'),
             'rateLimit' => config('api.rate_limit'),
             'paginationDefault' => config('api.pagination.per_page_default'),
             'paginationMin' => config('api.pagination.per_page_min'),
             'paginationMax' => config('api.pagination.per_page_max'),
+            'version' => $version,
+            'isPreRelease' => version_compare($version, '1.0.0', '<'),
         ])->title('Get Started');
     }
 }

--- a/app/Livewire/Portal/Docs/MenusIndexDoc.php
+++ b/app/Livewire/Portal/Docs/MenusIndexDoc.php
@@ -41,6 +41,7 @@ class MenusIndexDoc extends AbstractEndpointDoc
     {
         return [
             ['name' => 'id', 'type' => 'integer', 'description' => 'Menu ID'],
+            ['name' => 'url', 'type' => 'string', 'description' => 'URL to menu on website'],
             ['name' => 'year_week', 'type' => 'integer', 'description' => 'Year and week number (YYYYWW format)'],
             ['name' => 'start', 'type' => 'date', 'description' => 'Menu start date'],
             ['name' => 'recipes', 'type' => 'array', 'description' => 'Array of recipe objects (when include_recipes=true)'],

--- a/app/Livewire/Portal/Docs/MenusShowDoc.php
+++ b/app/Livewire/Portal/Docs/MenusShowDoc.php
@@ -29,6 +29,7 @@ class MenusShowDoc extends AbstractEndpointDoc
     {
         return [
             ['name' => 'id', 'type' => 'integer', 'description' => 'Menu ID'],
+            ['name' => 'url', 'type' => 'string', 'description' => 'URL to menu on website'],
             ['name' => 'year_week', 'type' => 'integer', 'description' => 'Year and week number (YYYYWW format)'],
             ['name' => 'start', 'type' => 'date', 'description' => 'Menu start date'],
             ['name' => 'recipes', 'type' => 'array', 'description' => 'Array of recipe objects'],

--- a/app/Livewire/Portal/Docs/RecipesShowDoc.php
+++ b/app/Livewire/Portal/Docs/RecipesShowDoc.php
@@ -44,6 +44,7 @@ class RecipesShowDoc extends AbstractEndpointDoc
             ['name' => 'ingredients', 'type' => 'array', 'description' => 'Recipe ingredients'],
             ['name' => 'cuisines', 'type' => 'array', 'description' => 'Cuisine types'],
             ['name' => 'utensils', 'type' => 'array', 'description' => 'Required utensils'],
+            ['name' => 'saved_in_lists', 'type' => 'array', 'description' => 'Lists where user saved this recipe'],
             ['name' => 'created_at', 'type' => 'datetime', 'description' => 'Creation timestamp'],
             ['name' => 'updated_at', 'type' => 'datetime', 'description' => 'Last update timestamp'],
         ];

--- a/resources/views/portal/components/layouts/app.blade.php
+++ b/resources/views/portal/components/layouts/app.blade.php
@@ -1,12 +1,28 @@
 @props([
     'title' => null,
 ])
+@php
+    $pageTitle = $title ? $title . ' - ' . config('app.name') . ' API' : config('app.name') . ' API Portal';
+@endphp
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ $title ? $title . ' - ' . config('app.name') . ' API' : config('app.name') . ' API Portal' }}</title>
+    <title>{{ $pageTitle }}</title>
+
+    {{-- Open Graph / Social Media Meta Tags --}}
+    <meta property="og:title" content="{{ $pageTitle }}">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ url()->current() }}">
+    <meta property="og:image" content="{{ route('og.generic', ['title' => $pageTitle, 'font' => 'mono']) }}">
+    <meta property="og:site_name" content="{{ config('app.name') }}">
+
+    {{-- Twitter Card --}}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ $pageTitle }}">
+    <meta name="twitter:image" content="{{ route('og.generic', ['title' => $pageTitle, 'font' => 'mono']) }}">
+
     <x-web::layouts.partials.favicon />
     @vite(['resources/css/portal/app.css'], 'build-portal')
     @livewireStyles

--- a/resources/views/portal/components/layouts/guest.blade.php
+++ b/resources/views/portal/components/layouts/guest.blade.php
@@ -1,12 +1,28 @@
 @props([
     'title' => null,
 ])
-  <!DOCTYPE html>
+@php
+    $pageTitle = $title ? $title . ' - ' . config('app.name') . ' API' : config('app.name') . ' API Portal';
+@endphp
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ $title ? $title . ' - ' . config('app.name') . ' API' : config('app.name') . ' API Portal' }}</title>
+  <title>{{ $pageTitle }}</title>
+
+  {{-- Open Graph / Social Media Meta Tags --}}
+  <meta property="og:title" content="{{ $pageTitle }}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ url()->current() }}">
+  <meta property="og:image" content="{{ route('og.generic', ['title' => $pageTitle, 'font' => 'mono']) }}">
+  <meta property="og:site_name" content="{{ config('app.name') }}">
+
+  {{-- Twitter Card --}}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ $pageTitle }}">
+  <meta name="twitter:image" content="{{ route('og.generic', ['title' => $pageTitle, 'font' => 'mono']) }}">
+
   <x-web::layouts.partials.favicon />
   @vite(['resources/css/portal/app.css'], 'build-portal')
   @livewireStyles

--- a/resources/views/portal/livewire/docs/get-started.blade.php
+++ b/resources/views/portal/livewire/docs/get-started.blade.php
@@ -49,6 +49,9 @@
         </flux:text>
         <pre class="mt-ui p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>X-RateLimit-Limit: {{ $rateLimit }}
 X-RateLimit-Remaining: {{ $rateLimit - 1 }}</code></pre>
+        <flux:text class="mt-section text-sm text-zinc-500 dark:text-zinc-400">
+            Note: The rate limit may be adjusted in the future. Always check the <code class="bg-zinc-100 dark:bg-zinc-700 px-1 rounded">X-RateLimit-Limit</code> header for the current limit.
+        </flux:text>
     </flux:card>
 
     <flux:card>
@@ -92,4 +95,13 @@ X-RateLimit-Remaining: {{ $rateLimit - 1 }}</code></pre>
   -H "Authorization: Bearer YOUR_API_TOKEN" \
   -H "Accept: application/json"</code></pre>
     </flux:card>
+
+    @if($isPreRelease)
+        <flux:callout icon="triangle-alert" color="amber">
+            <flux:callout.heading>Pre-Release API (v{{ $version }})</flux:callout.heading>
+            <flux:callout.text>
+                This API is currently in pre-release. Endpoints, response formats, and features may change without notice until version 1.0.0 is released. Use in production at your own risk.
+            </flux:callout.text>
+        </flux:callout>
+    @endif
 </div>


### PR DESCRIPTION
- Add `url` field to Menu API responses and documentation for localized menu URLs.
- Include `saved_in_lists` field in Recipe API responses for authenticated users.
- Update API portal layouts with improved metadata, including Open Graph and Twitter Card tags.
- Introduce pre-release warning for API versions below 1.0.0 in Get Started guide.
- Update Open Graph image generation to support mono font option.