### PR TITLE
refactor: replace `hellofresh_id` with `id` across recipe resources and routes

### DIFF
--- a/app/Http/Resources/Api/RecipeCollectionResource.php
+++ b/app/Http/Resources/Api/RecipeCollectionResource.php
@@ -28,7 +28,8 @@ class RecipeCollectionResource extends JsonResource
 
         return [
             'id' => $this->id,
-            'url' => config('app.url') . '/' . $locale . '-' . resolve('current.country')->code . '/recipes/' . slugify($this->getTranslationWithAnyFallback('name', $locale)) . '-' . $this->hellofresh_id,
+            'url' => config('app.url') . '/' . $locale . '-' . resolve('current.country')->code .
+                '/recipes/' . slugify($this->getTranslationWithAnyFallback('name', $locale)) . '-' . $this->id,
             'name' => $this->getTranslationWithAnyFallback('name', $locale),
             'headline' => $this->getTranslationWithAnyFallback('headline', $locale),
             'difficulty' => $this->difficulty,

--- a/app/Http/Resources/Api/RecipeResource.php
+++ b/app/Http/Resources/Api/RecipeResource.php
@@ -33,7 +33,8 @@ class RecipeResource extends JsonResource
 
         return [
             'id' => $this->id,
-            'url' => config('app.url') . '/' . $locale . '-' . resolve('current.country')->code . '/recipes/' . slugify($this->getTranslationWithAnyFallback('name', $locale)) . '-' . $this->hellofresh_id,
+            'url' => config('app.url') . '/' . $locale . '-' . resolve('current.country')->code .
+                '/recipes/' . slugify($this->getTranslationWithAnyFallback('name', $locale)) . '-' . $this->id,
             'name' => $this->getTranslationWithAnyFallback('name', $locale),
             'headline' => $this->getTranslationWithAnyFallback('headline', $locale),
             'description' => $this->getTranslationWithAnyFallback('description', $locale),

--- a/app/Jobs/GenerateSitemapJob.php
+++ b/app/Jobs/GenerateSitemapJob.php
@@ -84,7 +84,7 @@ class GenerateSitemapJob implements ShouldQueue
                     $slug = Str::slug($name, language: $this->locale);
                     $url = localized_route(
                         'localized.recipes.show',
-                        ['slug' => $slug, 'recipe' => $recipe->hellofresh_id],
+                        ['slug' => $slug, 'recipe' => $recipe->id],
                         true,
                         $this->country,
                         $this->locale

--- a/app/Livewire/Web/GlobalSearch.php
+++ b/app/Livewire/Web/GlobalSearch.php
@@ -52,7 +52,7 @@ class GlobalSearch extends AbstractComponent
 
         $this->redirect(
             localized_route('localized.recipes.show', [
-                'recipe' => $recipe->hellofresh_id,
+                'recipe' => $recipe->id,
                 'slug' => slugify($recipe->name),
             ]),
             navigate: true

--- a/resources/views/web/components/recipes/recipe-card.blade.php
+++ b/resources/views/web/components/recipes/recipe-card.blade.php
@@ -57,7 +57,7 @@
 
         <div class="p-4">
             <flux:heading size="lg" class="line-clamp-1">
-                <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->hellofresh_id])">
+                <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->id])">
                   {{ $recipe->name }}
                 </flux:link>
             </flux:heading>
@@ -107,7 +107,7 @@
         <div class="flex flex-1 flex-col justify-center py-2">
             <div class="flex items-center gap-2">
                 <flux:heading size="lg" class="line-clamp-1">
-                    <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->hellofresh_id])">
+                    <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->id])">
                       {{ $recipe->name }}
                     </flux:link>
                 </flux:heading>

--- a/resources/views/web/livewire/recipes/recipe-show.blade.php
+++ b/resources/views/web/livewire/recipes/recipe-show.blade.php
@@ -247,7 +247,7 @@
             @endif
             <div class="p-4">
               <flux:heading size="sm" class="line-clamp-2">
-                <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($similarRecipe->name), 'recipe' => $similarRecipe->hellofresh_id])">
+                <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($similarRecipe->name), 'recipe' => $similarRecipe->id])">
                   {{ $similarRecipe->name }}
                 </flux:link>
               </flux:heading>

--- a/resources/views/web/livewire/shopping-list/shopping-list-index.blade.php
+++ b/resources/views/web/livewire/shopping-list/shopping-list-index.blade.php
@@ -298,7 +298,7 @@
                 @endif
 
                 <div class="flex-1">
-                  <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->hellofresh_id])" wire:navigate class="print:hidden">
+                  <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->id])" wire:navigate class="print:hidden">
                     {{ $recipe->name }}
                   </flux:link>
                   <flux:heading size="sm" class="not-print:hidden">{{ $recipe->name }}</flux:heading>

--- a/resources/views/web/livewire/user/user-recipe-lists.blade.php
+++ b/resources/views/web/livewire/user/user-recipe-lists.blade.php
@@ -123,7 +123,7 @@
 
               <div class="p-4">
                 <flux:heading size="lg" class="line-clamp-1">
-                  <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->hellofresh_id])">
+                  <flux:link :href="localized_route('localized.recipes.show', ['slug' => slugify($recipe->name), 'recipe' => $recipe->id])">
                     {{ $recipe->name }}
                   </flux:link>
                 </flux:heading>

--- a/routes/web-localized.php
+++ b/routes/web-localized.php
@@ -13,8 +13,8 @@ use App\Livewire\Web\User\UserShoppingLists;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', RecipeIndex::class)->name('recipes.index');
-Route::get('recipes/{slug}-{recipe:hellofresh_id}', RecipeShow::class)
-    ->where(['slug' => '.*', 'recipe' => '[a-f0-9]{24}'])
+Route::get('recipes/{slug}-{recipe}', RecipeShow::class)
+    ->where(['slug' => '.*', 'recipe' => '[0-9]+'])
     ->name('recipes.show');
 Route::get('shopping-list', ShoppingListIndex::class)->name('shopping-list.index');
 Route::get('shopping-list/print', ShoppingListIndex::class)->name('shopping-list.print');


### PR DESCRIPTION
- Update URL generation logic in `RecipeResource` and `RecipeCollectionResource`.
- Modify Blade templates to use `id` for `localized.recipes.show` route.
- Adjust sitemap generation job to reference `id` instead of `hellofresh_id`.
- Update route definitions to simplify parameter validation for recipe identifiers.