### PR TITLE
feat: update Admin sidebar and dashboard grid layout

### DIFF
--- a/resources/views/portal/components/layouts/app.blade.php
+++ b/resources/views/portal/components/layouts/app.blade.php
@@ -78,7 +78,7 @@
       </flux:sidebar.item>
     </flux:sidebar.group>
       @if(auth()->user()?->admin)
-        <flux:sidebar.group expandable heading="Admin" class="grid">
+        <flux:sidebar.group expandable :expanded="false" heading="Admin" class="grid">
           <flux:sidebar.item icon="users" :href="route('portal.admin.users')" :current="request()->routeIs('portal.admin.users')" wire:navigate>
             Users
           </flux:sidebar.item>

--- a/resources/views/portal/livewire/dashboard.blade.php
+++ b/resources/views/portal/livewire/dashboard.blade.php
@@ -7,7 +7,7 @@
     alt="Laravel Forge Site Deployment Status"
   />
 
-  <div class="grid gap-section md:grid-cols-2 lg:grid-cols-3">
+  <div class="grid gap-section md:grid-cols-2 xl:grid-cols-3">
     @if($isAuthenticated)
       <flux:card>
         <flux:heading size="lg">API Tokens</flux:heading>


### PR DESCRIPTION
- Set Admin sidebar group to collapsed by default.
- Adjust dashboard grid layout for better responsiveness on larger screens.