### PR TITLE
feat: add API specifications download feature

### DIFF
--- a/app/Console/Commands/ApiSpecsCommand.php
+++ b/app/Console/Commands/ApiSpecsCommand.php
@@ -1,0 +1,455 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Livewire\Portal\Docs\AbstractEndpointDoc;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use ReflectionClass;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Finder\Finder;
+
+#[AsCommand(name: 'api:specs')]
+class ApiSpecsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'api:specs';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate OpenAPI and Postman collection specs from API documentation';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): void
+    {
+        $endpoints = $this->collectEndpoints();
+
+        $this->generateOpenApiSpec($endpoints);
+        $this->generatePostmanCollection($endpoints);
+
+        $this->components->info('API specs generated successfully.');
+    }
+
+    /**
+     * Collect endpoint data from all Doc classes.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function collectEndpoints(): array
+    {
+        $endpoints = [];
+        $docClasses = $this->getDocClasses();
+
+        foreach ($docClasses as $docClass) {
+            $instance = resolve($docClass);
+            $reflection = new ReflectionClass($instance);
+
+            $endpoints[] = [
+                'title' => $this->callProtectedMethod($instance, $reflection, 'title'),
+                'description' => $this->callProtectedMethod($instance, $reflection, 'description'),
+                'endpoints' => $this->callProtectedMethod($instance, $reflection, 'endpoints'),
+                'queryParams' => $this->callProtectedMethod($instance, $reflection, 'queryParams'),
+                'responseFields' => $this->callProtectedMethod($instance, $reflection, 'responseFields'),
+            ];
+        }
+
+        return $endpoints;
+    }
+
+    /**
+     * Get all Doc classes extending AbstractEndpointDoc.
+     *
+     * @return array<int, class-string>
+     */
+    protected function getDocClasses(): array
+    {
+        $path = app_path('Livewire/Portal/Docs');
+        $namespace = 'App\\Livewire\\Portal\\Docs';
+
+        $finder = Finder::create()
+            ->files()
+            ->name('*Doc.php')
+            ->notName('AbstractEndpointDoc.php')
+            ->notName('GetStartedDoc.php')
+            ->in($path);
+
+        $classes = [];
+
+        foreach ($finder as $file) {
+            $className = $namespace . '\\' . $file->getBasename('.php');
+
+            if (class_exists($className) && is_subclass_of($className, AbstractEndpointDoc::class)) {
+                $classes[] = $className;
+            }
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Call a protected method on the Doc instance.
+     *
+     * @param  ReflectionClass<object>  $reflection
+     */
+    protected function callProtectedMethod(object $instance, ReflectionClass $reflection, string $methodName): mixed
+    {
+        if (! $reflection->hasMethod($methodName)) {
+            return null;
+        }
+
+        $method = $reflection->getMethod($methodName);
+
+        return $method->invoke($instance);
+    }
+
+    /**
+     * Generate OpenAPI 3.0 specification.
+     *
+     * @param  array<int, array<string, mixed>>  $endpoints
+     */
+    protected function generateOpenApiSpec(array $endpoints): void
+    {
+        $spec = [
+            'openapi' => '3.0.3',
+            'info' => [
+                'title' => config('app.name') . ' API',
+                'description' => 'API for accessing HelloFresh recipe data',
+                'version' => config('api.version'),
+                'contact' => [
+                    'name' => 'Norman Huth',
+                    'url' => config('app.url'),
+                ],
+            ],
+            'servers' => [
+                [
+                    'url' => 'https://' . config('api.domain_name') . '/{locale}-{country}',
+                    'variables' => [
+                        'locale' => [
+                            'default' => 'en',
+                            'description' => 'Language code (e.g., en, de, fr)',
+                        ],
+                        'country' => [
+                            'default' => 'US',
+                            'description' => 'Country code (e.g., US, DE, GB)',
+                        ],
+                    ],
+                ],
+            ],
+            'security' => [
+                ['bearerAuth' => []],
+            ],
+            'paths' => [],
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => [
+                        'type' => 'http',
+                        'scheme' => 'bearer',
+                        'bearerFormat' => 'API Token',
+                    ],
+                ],
+            ],
+        ];
+
+        foreach ($endpoints as $endpoint) {
+            foreach ($endpoint['endpoints'] as $endpointItem) {
+                $path = $this->convertPathToOpenApi($endpointItem['path']);
+                $method = strtolower((string) $endpointItem['method']);
+
+                $operation = [
+                    'summary' => $endpoint['title'],
+                    'description' => $endpoint['description'],
+                    'tags' => [$this->extractTag($endpoint['title'])],
+                    'responses' => [
+                        '200' => [
+                            'description' => 'Successful response',
+                            'content' => [
+                                'application/json' => [
+                                    'schema' => $this->buildResponseSchema($endpoint['responseFields']),
+                                ],
+                            ],
+                        ],
+                        '401' => ['description' => 'Unauthorized'],
+                        '404' => ['description' => 'Not found'],
+                        '429' => ['description' => 'Too many requests'],
+                    ],
+                ];
+
+                if (! empty($endpoint['queryParams'])) {
+                    $operation['parameters'] = $this->buildQueryParameters($endpoint['queryParams']);
+                }
+
+                $pathParams = $this->extractPathParameters($endpointItem['path']);
+                if ($pathParams !== []) {
+                    $operation['parameters'] = array_merge(
+                        $operation['parameters'] ?? [],
+                        $pathParams
+                    );
+                }
+
+                $spec['paths'][$path][$method] = $operation;
+            }
+        }
+
+        Storage::disk('local')->put(
+            'api-docs/openapi/openapi.json',
+            (string) json_encode($spec, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $this->components->twoColumnDetail('OpenAPI spec', Storage::disk('local')->path('api-docs/openapi/openapi.json'));
+    }
+
+    /**
+     * Generate Postman collection.
+     *
+     * @param  array<int, array<string, mixed>>  $endpoints
+     */
+    protected function generatePostmanCollection(array $endpoints): void
+    {
+        $collection = [
+            'info' => [
+                'name' => config('app.name') . ' API',
+                'description' => 'API for accessing HelloFresh recipe data',
+                'schema' => 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+            ],
+            'auth' => [
+                'type' => 'bearer',
+                'bearer' => [
+                    [
+                        'key' => 'token',
+                        'value' => '{{API_TOKEN}}',
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'variable' => [
+                [
+                    'key' => 'BASE_URL',
+                    'value' => 'https://' . config('api.domain_name'),
+                ],
+                [
+                    'key' => 'LOCALE',
+                    'value' => 'en',
+                ],
+                [
+                    'key' => 'COUNTRY',
+                    'value' => 'US',
+                ],
+                [
+                    'key' => 'API_TOKEN',
+                    'value' => 'YOUR_API_TOKEN',
+                ],
+            ],
+            'item' => [],
+        ];
+
+        foreach ($endpoints as $endpoint) {
+            foreach ($endpoint['endpoints'] as $endpointItem) {
+                $item = [
+                    'name' => $endpoint['title'],
+                    'request' => [
+                        'method' => $endpointItem['method'],
+                        'header' => [
+                            [
+                                'key' => 'Accept',
+                                'value' => 'application/json',
+                            ],
+                        ],
+                        'url' => [
+                            'raw' => '{{BASE_URL}}/{{LOCALE}}-{{COUNTRY}}' . $this->convertPathToPostman($endpointItem['path']),
+                            'host' => ['{{BASE_URL}}'],
+                            'path' => $this->buildPostmanPath($endpointItem['path']),
+                        ],
+                        'description' => $endpoint['description'],
+                    ],
+                ];
+
+                if (! empty($endpoint['queryParams'])) {
+                    $item['request']['url']['query'] = $this->buildPostmanQueryParams($endpoint['queryParams']);
+                }
+
+                $collection['item'][] = $item;
+            }
+        }
+
+        Storage::disk('local')->put(
+            'api-docs/postman/collection.json',
+            (string) json_encode($collection, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+        );
+
+        $this->components->twoColumnDetail('Postman collection', Storage::disk('local')->path('api-docs/postman/collection.json'));
+    }
+
+    /**
+     * Convert path from docs format to OpenAPI format.
+     */
+    protected function convertPathToOpenApi(string $path): string
+    {
+        // Remove locale-country prefix as it's in server URL
+        $path = preg_replace('#^/\{locale\}-\{country\}#', '', $path);
+
+        return $path ?: '/';
+    }
+
+    /**
+     * Convert path from docs format to Postman format.
+     */
+    protected function convertPathToPostman(string $path): string
+    {
+        // Remove locale-country prefix as it's handled separately
+        $path = (string) preg_replace('#^/\{locale\}-\{country\}#', '', $path);
+
+        // Convert {param} to :param
+        return (string) preg_replace('/\{([^}]+)\}/', ':$1', $path);
+    }
+
+    /**
+     * Build Postman path array.
+     *
+     * @return array<int, string>
+     */
+    protected function buildPostmanPath(string $path): array
+    {
+        $path = preg_replace('#^/\{locale\}-\{country\}#', '', $path);
+        $path = preg_replace('/\{([^}]+)\}/', ':$1', (string) $path) ?? $path;
+
+        $segments = array_filter(explode('/', (string) $path));
+
+        return array_merge(['{{LOCALE}}-{{COUNTRY}}'], array_values($segments));
+    }
+
+    /**
+     * Build query parameters for OpenAPI.
+     *
+     * @param  array<int, array<string, string>>  $params
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildQueryParameters(array $params): array
+    {
+        return array_map(static fn (array $param): array => [
+            'name' => $param['name'],
+            'in' => 'query',
+            'required' => false,
+            'description' => $param['description'],
+            'schema' => [
+                'type' => match ($param['type']) {
+                    'integer' => 'integer',
+                    'boolean' => 'boolean',
+                    default => 'string',
+                },
+            ],
+        ], $params);
+    }
+
+    /**
+     * Build Postman query params.
+     *
+     * @param  array<int, array<string, string>>  $params
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildPostmanQueryParams(array $params): array
+    {
+        return array_map(static fn (array $param): array => [
+            'key' => $param['name'],
+            'value' => '',
+            'description' => $param['description'],
+            'disabled' => true,
+        ], $params);
+    }
+
+    /**
+     * Extract path parameters from path.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function extractPathParameters(string $path): array
+    {
+        $params = [];
+
+        // Remove locale-country as it's in server URL
+        $path = preg_replace('#^/\{locale\}-\{country\}#', '', $path);
+
+        preg_match_all('/\{([^}]+)\}/', $path ?? '', $matches);
+
+        foreach ($matches[1] as $param) {
+            $params[] = [
+                'name' => $param,
+                'in' => 'path',
+                'required' => true,
+                'schema' => [
+                    'type' => $param === 'id' || $param === 'year_week' ? 'integer' : 'string',
+                ],
+            ];
+        }
+
+        return $params;
+    }
+
+    /**
+     * Build response schema from response fields.
+     *
+     * @param  array<int, array<string, string>>  $fields
+     * @return array<string, mixed>
+     */
+    protected function buildResponseSchema(array $fields): array
+    {
+        $properties = [];
+
+        foreach ($fields as $field) {
+            $properties[$field['name']] = [
+                'type' => $this->mapFieldType($field['type']),
+                'description' => $field['description'],
+            ];
+
+            if (str_contains($field['type'], 'null')) {
+                $properties[$field['name']]['nullable'] = true;
+            }
+        }
+
+        return [
+            'type' => 'object',
+            'properties' => $properties,
+        ];
+    }
+
+    /**
+     * Map doc field type to OpenAPI type.
+     */
+    protected function mapFieldType(string $type): string
+    {
+        $type = str_replace('|null', '', $type);
+
+        return match ($type) {
+            'integer', 'int' => 'integer',
+            'boolean', 'bool' => 'boolean',
+            'array' => 'array',
+            'object' => 'object',
+            'datetime', 'date' => 'string',
+            default => 'string',
+        };
+    }
+
+    /**
+     * Extract tag from endpoint title.
+     */
+    protected function extractTag(string $title): string
+    {
+        // "List Recipes" -> "Recipes", "Get Recipe" -> "Recipes", "Allergens API" -> "Allergens"
+        $title = str_replace([' API', 'List ', 'Get '], '', $title);
+
+        // Singularize if needed
+        if (! str_ends_with($title, 's')) {
+            $title .= 's';
+        }
+
+        return $title;
+    }
+}

--- a/resources/views/flux/icon/file-down.blade.php
+++ b/resources/views/flux/icon/file-down.blade.php
@@ -1,0 +1,46 @@
+@blaze
+
+{{-- Credit: Lucide (https://lucide.dev) --}}
+
+@props([
+    'variant' => 'outline',
+])
+
+@php
+if ($variant === 'solid') {
+    throw new \Exception('The "solid" variant is not supported in Lucide.');
+}
+
+$classes = Flux::classes('shrink-0')
+    ->add(match($variant) {
+        'outline' => '[:where(&)]:size-6',
+        'solid' => '[:where(&)]:size-6',
+        'mini' => '[:where(&)]:size-5',
+        'micro' => '[:where(&)]:size-4',
+    });
+
+$strokeWidth = match ($variant) {
+    'outline' => 2,
+    'mini' => 2.25,
+    'micro' => 2.5,
+};
+@endphp
+
+<svg
+    {{ $attributes->class($classes) }}
+    data-flux-icon
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="{{ $strokeWidth }}"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    data-slot="icon"
+>
+  <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+  <path d="M12 18v-6" />
+  <path d="m9 15 3 3 3-3" />
+</svg>

--- a/resources/views/portal/components/api-specs-download.blade.php
+++ b/resources/views/portal/components/api-specs-download.blade.php
@@ -1,0 +1,42 @@
+@php
+  use Illuminate\Support\Facades\Storage;
+
+  $hasOpenApiSpec = Storage::disk('local')->exists('api-docs/openapi/openapi.json');
+  $hasPostmanCollection = Storage::disk('local')->exists('api-docs/postman/collection.json');
+  $hasAnySpec = $hasOpenApiSpec || $hasPostmanCollection;
+  $isAuthenticated = auth()->check();
+@endphp
+
+@if($hasAnySpec)
+  <flux:card>
+    <flux:heading size="lg">API Specifications</flux:heading>
+    <flux:text class="mt-ui">
+      Download the API specification files to import into your favorite API client.
+    </flux:text>
+    <div class="mt-section flex flex-wrap gap-ui">
+      @if($hasOpenApiSpec)
+        <flux:button
+          :href="$isAuthenticated ? route('portal.docs.download.openapi') : null"
+          icon="file-down"
+          :disabled="!$isAuthenticated"
+        >
+          OpenAPI 3.0 (Swagger)
+        </flux:button>
+      @endif
+      @if($hasPostmanCollection)
+        <flux:button
+          :href="$isAuthenticated ? route('portal.docs.download.postman') : null"
+          icon="file-down"
+          :disabled="!$isAuthenticated"
+        >
+          Postman Collection
+        </flux:button>
+      @endif
+    </div>
+    @guest
+      <flux:text class="mt-section text-sm text-zinc-500 dark:text-zinc-400">
+        <flux:link href="{{ route('portal.login') }}" wire:navigate>Sign in</flux:link> to download the specification files.
+      </flux:text>
+    @endguest
+  </flux:card>
+@endif

--- a/resources/views/portal/livewire/dashboard.blade.php
+++ b/resources/views/portal/livewire/dashboard.blade.php
@@ -60,6 +60,8 @@
     </flux:card>
   </div>
 
+  <x-portal::api-specs-download />
+
   @if($isAuthenticated && $usageStats && $usageStats['total'] > 0)
     <flux:card>
       <flux:heading size="lg">API Usage</flux:heading>

--- a/resources/views/portal/livewire/docs/get-started.blade.php
+++ b/resources/views/portal/livewire/docs/get-started.blade.php
@@ -96,6 +96,8 @@ X-RateLimit-Remaining: {{ $rateLimit - 1 }}</code></pre>
   -H "Accept: application/json"</code></pre>
     </flux:card>
 
+    <x-portal::api-specs-download />
+
     @if($isPreRelease)
         <flux:callout icon="triangle-alert" color="amber">
             <flux:callout.heading>Pre-Release API (v{{ $version }})</flux:callout.heading>

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -24,6 +24,8 @@ use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /*
 |--------------------------------------------------------------------------
@@ -85,6 +87,23 @@ Route::middleware('auth')->group(function (): void {
     // API Tokens
     Route::prefix('tokens')->name('tokens.')->group(function (): void {
         Route::get('', TokenIndex::class)->name('index');
+    });
+
+    // API Specs Downloads
+    Route::prefix('docs/download')->name('docs.download.')->group(function (): void {
+        Route::get('openapi', static function (): StreamedResponse {
+            return Storage::disk('local')->download(
+                'api-docs/openapi/openapi.json',
+                'hfresh-openapi.json'
+            );
+        })->name('openapi');
+
+        Route::get('postman', static function (): StreamedResponse {
+            return Storage::disk('local')->download(
+                'api-docs/postman/collection.json',
+                'hfresh-postman-collection.json'
+            );
+        })->name('postman');
     });
 
     // Admin routes


### PR DESCRIPTION
- Introduce buttons to download OpenAPI 3.0 and Postman Collection specs in portal views.
- Add routes to handle file downloads for generated API specs.
- Create `ApiSpecsCommand` to generate OpenAPI and Postman spec files dynamically.
- Update dashboard and get-started views to include spec download component.