### PR TITLE
feat(jobs): add activation and orchestration jobs for country resources

### DIFF
--- a/app/Console/Commands/ApiSpecsCommand.php
+++ b/app/Console/Commands/ApiSpecsCommand.php
@@ -201,7 +201,7 @@ class ApiSpecsCommand extends Command
 
         Storage::disk('local')->put(
             'api-docs/openapi/openapi.json',
-            (string) json_encode($spec, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+            (string) json_encode($spec, JSON_UNESCAPED_SLASHES)
         );
 
         $this->components->twoColumnDetail('OpenAPI spec', Storage::disk('local')->path('api-docs/openapi/openapi.json'));
@@ -282,7 +282,7 @@ class ApiSpecsCommand extends Command
 
         Storage::disk('local')->put(
             'api-docs/postman/collection.json',
-            (string) json_encode($collection, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)
+            (string) json_encode($collection, JSON_UNESCAPED_SLASHES)
         );
 
         $this->components->twoColumnDetail('Postman collection', Storage::disk('local')->path('api-docs/postman/collection.json'));

--- a/app/Http/Controllers/Portal/ApiSpecDownloadController.php
+++ b/app/Http/Controllers/Portal/ApiSpecDownloadController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Portal;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ApiSpecDownloadController extends Controller
+{
+    public function openapi(): StreamedResponse
+    {
+        return Storage::disk('local')->download(
+            'api-docs/openapi/openapi.json',
+            'hfresh-openapi.json'
+        );
+    }
+
+    public function postman(): StreamedResponse
+    {
+        return Storage::disk('local')->download(
+            'api-docs/postman/collection.json',
+            'hfresh-postman-collection.json'
+        );
+    }
+}

--- a/app/Http/Controllers/Portal/VerifyEmailController.php
+++ b/app/Http/Controllers/Portal/VerifyEmailController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\Portal;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
+use Illuminate\Http\RedirectResponse;
+
+class VerifyEmailController extends Controller
+{
+    public function __invoke(EmailVerificationRequest $request): RedirectResponse
+    {
+        $request->fulfill();
+
+        return to_route('portal.dashboard')
+            ->with('success', 'Your email has been verified successfully.');
+    }
+}

--- a/app/Jobs/Country/ActivateCountryResourcesJob.php
+++ b/app/Jobs/Country/ActivateCountryResourcesJob.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Jobs\Country;
+
+use App\Enums\QueueEnum;
+use App\Models\Allergen;
+use App\Models\Country;
+use App\Models\Cuisine;
+use App\Models\Ingredient;
+use App\Models\Label;
+use App\Models\Tag;
+use App\Models\Utensil;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Foundation\Queue\Queueable;
+
+/**
+ * Updates the active status for activatable models based on recipe count.
+ */
+class ActivateCountryResourcesJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        protected Country $country,
+    ) {
+        $this->onQueue(QueueEnum::Long->value);
+    }
+
+    public function handle(): void
+    {
+        $countryId = $this->country->getKey();
+
+        // Update allergens - use withCount to get recipe counts efficiently
+        Allergen::where('country_id', $countryId)
+            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
+            ->get()
+            ->each(fn (Allergen $allergen) => $allergen->updateQuietly(['active' => $allergen->recipes_count > 3]));
+
+        // Update cuisines
+        Cuisine::where('country_id', $countryId)
+            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
+            ->get()
+            ->each(fn (Cuisine $cuisine) => $cuisine->updateQuietly(['active' => $cuisine->recipes_count > 3]));
+
+        // Update tags
+        Tag::where('country_id', $countryId)
+            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
+            ->get()
+            ->each(fn (Tag $tag) => $tag->updateQuietly(['active' => $tag->recipes_count > 3]));
+
+        // Update utensils
+        Utensil::where('country_id', $countryId)
+            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
+            ->get()
+            ->each(fn (Utensil $utensil) => $utensil->updateQuietly(['active' => $utensil->recipes_count > 3]));
+
+        // Update labels
+        Label::where('country_id', $countryId)
+            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
+            ->get()
+            ->each(fn (Label $label) => $label->updateQuietly(['active' => $label->recipes_count > 3]));
+
+        // Update ingredients
+        Ingredient::where('country_id', $countryId)
+            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
+            ->get()
+            ->each(fn (Ingredient $ingredient) => $ingredient->updateQuietly(['active' => $ingredient->recipes_count > 0]));
+    }
+}

--- a/app/Jobs/Country/CountryResourcesOrchestrationJob.php
+++ b/app/Jobs/Country/CountryResourcesOrchestrationJob.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Jobs\Country;
+
+use App\Contracts\LauncherJobInterface;
+use App\Enums\QueueEnum;
+use App\Models\Country;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+/**
+ * Orchestrator job that dispatches UpdateActivatableModelsForCountryJob for each country.
+ */
+class CountryResourcesOrchestrationJob implements LauncherJobInterface, ShouldQueue
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        $this->onQueue(QueueEnum::Long->value);
+    }
+
+    public static function description(): string
+    {
+        return 'Update active status for activatable models for all countries';
+    }
+
+    public function handle(): void
+    {
+        Country::each(static fn (Country $country) => ActivateCountryResourcesJob::dispatch($country));
+    }
+}

--- a/app/Jobs/Country/UpdateCountryStatisticsJob.php
+++ b/app/Jobs/Country/UpdateCountryStatisticsJob.php
@@ -1,18 +1,11 @@
 <?php
 
-namespace App\Jobs;
+namespace App\Jobs\Country;
 
 use App\Contracts\LauncherJobInterface;
 use App\Enums\QueueEnum;
-use App\Models\Allergen;
 use App\Models\Country;
-use App\Models\Cuisine;
-use App\Models\Ingredient;
-use App\Models\Label;
-use App\Models\Tag;
-use App\Models\Utensil;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Queue\Queueable;
 
 /**
@@ -57,8 +50,6 @@ class UpdateCountryStatisticsJob implements LauncherJobInterface, ShouldQueue
      */
     protected function updateCountryStatistics(Country $country): void
     {
-        $this->updateActivatableModels($country);
-
         $recipes = $country->recipes();
         $prepRecipes = (clone $recipes)->where('prep_time', '>', 0);
         $totalRecipes = (clone $recipes)->where('total_time', '>', 0);
@@ -84,49 +75,5 @@ class UpdateCountryStatisticsJob implements LauncherJobInterface, ShouldQueue
             'has_tags' => $country->tags()->where('active', true)->count() > 3,
             'has_utensil' => $country->utensils()->where('active', true)->count() > 3,
         ]);
-    }
-
-    /**
-     * Update active status for all activatable models based on recipe count.
-     */
-    protected function updateActivatableModels(Country $country): void
-    {
-        $countryId = $country->getKey();
-
-        // Update allergens - use withCount to get recipe counts efficiently
-        Allergen::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Allergen $allergen) => $allergen->updateQuietly(['active' => $allergen->recipes_count > 3]));
-
-        // Update cuisines
-        Cuisine::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Cuisine $cuisine) => $cuisine->updateQuietly(['active' => $cuisine->recipes_count > 3]));
-
-        // Update tags
-        Tag::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Tag $tag) => $tag->updateQuietly(['active' => $tag->recipes_count > 3]));
-
-        // Update utensils
-        Utensil::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Utensil $utensil) => $utensil->updateQuietly(['active' => $utensil->recipes_count > 3]));
-
-        // Update labels
-        Label::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Label $label) => $label->updateQuietly(['active' => $label->recipes_count > 3]));
-
-        // Update ingredients
-        Ingredient::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Ingredient $ingredient) => $ingredient->updateQuietly(['active' => $ingredient->recipes_count > 0]));
     }
 }

--- a/app/Livewire/Actions/Portal/LogoutAction.php
+++ b/app/Livewire/Actions/Portal/LogoutAction.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Livewire\Actions\Portal;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Session;
+
+class LogoutAction
+{
+    public function __invoke(): RedirectResponse
+    {
+        auth()->logout();
+
+        Session::invalidate();
+        Session::regenerateToken();
+
+        return to_route('portal.dashboard');
+    }
+}

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -247,7 +247,7 @@ return [
             'maxJobs' => 0,
             'memory' => 1024,
             'tries' => 1,
-            'timeout' => 900,
+            'timeout' => 1800,
             'nice' => 0,
         ],
     ],

--- a/resources/views/portal/components/api-specs-download.blade.php
+++ b/resources/views/portal/components/api-specs-download.blade.php
@@ -1,42 +1,41 @@
 @php
-  use Illuminate\Support\Facades\Storage;
+    use Illuminate\Support\Facades\Storage;
 
-  $hasOpenApiSpec = Storage::disk('local')->exists('api-docs/openapi/openapi.json');
-  $hasPostmanCollection = Storage::disk('local')->exists('api-docs/postman/collection.json');
-  $hasAnySpec = $hasOpenApiSpec || $hasPostmanCollection;
-  $isAuthenticated = auth()->check();
+    $hasOpenApiSpec = Storage::disk('local')->exists('api-docs/openapi/openapi.json');
+    $hasPostmanCollection = Storage::disk('local')->exists('api-docs/postman/collection.json');
+    $isAuthenticated = true;
 @endphp
 
-@if($hasAnySpec)
-  <flux:card>
-    <flux:heading size="lg">API Specifications</flux:heading>
-    <flux:text class="mt-ui">
-      Download the API specification files to import into your favorite API client.
-    </flux:text>
-    <div class="mt-section flex flex-wrap gap-ui">
-      @if($hasOpenApiSpec)
-        <flux:button
-          :href="$isAuthenticated ? route('portal.docs.download.openapi') : null"
-          icon="file-down"
-          :disabled="!$isAuthenticated"
-        >
-          OpenAPI 3.0 (Swagger)
-        </flux:button>
-      @endif
-      @if($hasPostmanCollection)
-        <flux:button
-          :href="$isAuthenticated ? route('portal.docs.download.postman') : null"
-          icon="file-down"
-          :disabled="!$isAuthenticated"
-        >
-          Postman Collection
-        </flux:button>
-      @endif
-    </div>
-    @guest
-      <flux:text class="mt-section text-sm text-zinc-500 dark:text-zinc-400">
-        <flux:link href="{{ route('portal.login') }}" wire:navigate>Sign in</flux:link> to download the specification files.
-      </flux:text>
-    @endguest
-  </flux:card>
+@if($hasOpenApiSpec || $hasPostmanCollection)
+    <flux:card>
+        <flux:heading size="lg">API Specifications</flux:heading>
+        <flux:text class="mt-ui">
+            Download the API specification files to import into your favorite API client.
+        </flux:text>
+        <div class="mt-section flex flex-wrap gap-ui">
+            @if($hasOpenApiSpec)
+                <flux:button
+                    :href="$isAuthenticated ? route('portal.docs.download.openapi') : null"
+                    icon="file-down"
+                    :disabled="!$isAuthenticated"
+                >
+                    OpenAPI 3.0 (Swagger)
+                </flux:button>
+            @endif
+            @if($hasPostmanCollection)
+                <flux:button
+                    :href="$isAuthenticated ? route('portal.docs.download.postman') : null"
+                    icon="file-down"
+                    :disabled="!$isAuthenticated"
+                >
+                    Postman Collection
+                </flux:button>
+            @endif
+        </div>
+        @if(!$isAuthenticated)
+            <flux:text class="mt-section text-sm text-zinc-500 dark:text-zinc-400">
+                <flux:link :href="route('portal.login')" wire:navigate>Sign in</flux:link> to download the specification files.
+            </flux:text>
+        @endif
+    </flux:card>
 @endif

--- a/resources/views/portal/components/layouts/app.blade.php
+++ b/resources/views/portal/components/layouts/app.blade.php
@@ -110,7 +110,7 @@
       <flux:sidebar.profile name="{{ auth()->user()->name }}" />
 
       <flux:menu>
-        <flux:menu.item icon="user" href="{{ route('portal.profile') }}">Profile</flux:menu.item>
+        <flux:menu.item icon="user" :href="route('portal.profile')">Profile</flux:menu.item>
         <flux:menu.item icon="home" href="{{ config('app.url') }}">{{ config('app.name') }}</flux:menu.item>
         <flux:menu.separator />
         <flux:menu.item icon="log-out" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
@@ -148,7 +148,7 @@
       <flux:profile name="{{ auth()->user()->name }}" />
 
       <flux:menu>
-        <flux:menu.item icon="user" href="{{ route('portal.profile') }}">Profile</flux:menu.item>
+        <flux:menu.item icon="user" :href="route('portal.profile')">Profile</flux:menu.item>
         <flux:menu.separator />
         <flux:menu.item icon="log-out" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
           Logout

--- a/resources/views/portal/livewire/auth/login.blade.php
+++ b/resources/views/portal/livewire/auth/login.blade.php
@@ -2,7 +2,7 @@
     <div class="text-center">
         <flux:heading size="lg">Sign in to your account</flux:heading>
         <flux:text class="mt-ui">
-            Or <flux:link href="{{ route('portal.register') }}" wire:navigate>create a new account</flux:link>
+            Or <flux:link :href="route('portal.register')" wire:navigate>create a new account</flux:link>
         </flux:text>
     </div>
 

--- a/resources/views/portal/livewire/auth/register.blade.php
+++ b/resources/views/portal/livewire/auth/register.blade.php
@@ -2,7 +2,7 @@
     <div class="text-center">
         <flux:heading size="lg">Create your account</flux:heading>
         <flux:text class="mt-ui">
-            Already have an account? <flux:link href="{{ route('portal.login') }}" wire:navigate>Sign in</flux:link>
+            Already have an account? <flux:link :href="route('portal.login')" wire:navigate>Sign in</flux:link>
         </flux:text>
     </div>
 

--- a/resources/views/portal/livewire/auth/verify-email.blade.php
+++ b/resources/views/portal/livewire/auth/verify-email.blade.php
@@ -18,7 +18,7 @@
     </flux:button>
 
     <div class="text-center">
-        <flux:link href="{{ route('portal.dashboard') }}" variant="subtle" wire:navigate>
+        <flux:link :href="route('portal.dashboard')" variant="subtle" wire:navigate>
             Skip for now
         </flux:link>
     </div>

--- a/resources/views/portal/livewire/dashboard.blade.php
+++ b/resources/views/portal/livewire/dashboard.blade.php
@@ -15,7 +15,7 @@
           You have <strong>{{ $tokenCount }}</strong> active API {{ Str::plural('token', $tokenCount) }}.
         </flux:text>
         <div class="mt-section">
-          <flux:button href="{{ route('portal.tokens.index') }}" variant="primary" wire:navigate>
+          <flux:button :href="route('portal.tokens.index')" variant="primary" wire:navigate>
             Manage Tokens
           </flux:button>
         </div>
@@ -27,10 +27,10 @@
           Create an account to get your API tokens and start integrating with our API.
         </flux:text>
         <div class="mt-section flex gap-ui">
-          <flux:button href="{{ route('portal.register') }}" variant="primary" wire:navigate>
+          <flux:button :href="route('portal.register')" variant="primary" wire:navigate>
             Sign Up
           </flux:button>
-          <flux:button href="{{ route('portal.login') }}" wire:navigate>
+          <flux:button :href="route('portal.login')" wire:navigate>
             Sign In
           </flux:button>
         </div>
@@ -43,7 +43,7 @@
         Learn how to authenticate and make your first API request.
       </flux:text>
       <div class="mt-section">
-        <flux:button href="{{ route('portal.docs.get-started') }}" wire:navigate>
+        <flux:button :href="route('portal.docs.get-started')" wire:navigate>
           View API Docs
         </flux:button>
       </div>

--- a/resources/views/portal/livewire/docs/get-started.blade.php
+++ b/resources/views/portal/livewire/docs/get-started.blade.php
@@ -18,9 +18,9 @@
         <pre class="mt-section p-section bg-zinc-900 text-zinc-100 rounded-lg text-sm overflow-x-auto"><code>Authorization: Bearer YOUR_API_TOKEN</code></pre>
         <flux:text class="mt-section text-sm">
             @auth
-                You can manage your API tokens in the <flux:link href="{{ route('portal.tokens.index') }}" wire:navigate>Token Management</flux:link> section.
+                You can manage your API tokens in the <flux:link :href="route('portal.tokens.index')" wire:navigate>Token Management</flux:link> section.
             @else
-                <flux:link href="{{ route('portal.login') }}" wire:navigate>Sign in</flux:link> to create and manage your API tokens.
+                <flux:link :href="route('portal.login')" wire:navigate>Sign in</flux:link> to create and manage your API tokens.
             @endauth
         </flux:text>
     </flux:card>
@@ -35,7 +35,7 @@
             Example: <code class="bg-zinc-100 dark:bg-zinc-700 px-1 rounded">de-DE</code> for German (Germany), <code class="bg-zinc-100 dark:bg-zinc-700 px-1 rounded">en-GB</code> for English (Great Britain).
         </flux:text>
         <flux:text class="mt-ui text-sm">
-            Use the <flux:link href="{{ route('portal.docs.countries') }}" wire:navigate>Countries endpoint</flux:link> to get a list of available countries.
+            Use the <flux:link :href="route('portal.docs.countries')" wire:navigate>Countries endpoint</flux:link> to get a list of available countries.
         </flux:text>
     </flux:card>
 

--- a/resources/views/web/components/layouts/localized/footer.blade.php
+++ b/resources/views/web/components/layouts/localized/footer.blade.php
@@ -9,7 +9,7 @@
         <flux:icon.github variant="micro" />
         <span>GitHub</span>
       </flux:link>
-      <flux:link href="{{ route('portal.dashboard') }}" class="inline-flex items-center gap-1 hover:text-zinc-700 dark:hover:text-zinc-200">
+      <flux:link :href="route('portal.dashboard')" class="inline-flex items-center gap-1 hover:text-zinc-700 dark:hover:text-zinc-200">
         <flux:icon.code variant="micro" />
         <span>API</span>
       </flux:link>

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,9 +1,10 @@
 <?php
 
+use App\Jobs\Country\CountryResourcesOrchestrationJob;
+use App\Jobs\Country\UpdateCountryStatisticsJob;
 use App\Jobs\GenerateSitemapsJob;
 use App\Jobs\Menu\SyncMenusJob;
 use App\Jobs\Recipe\SyncRecipesJob;
-use App\Jobs\UpdateCountryStatisticsJob;
 use Illuminate\Console\Scheduling\Schedule as ConsoleSchedule;
 use Illuminate\Support\Facades\Schedule;
 
@@ -24,6 +25,9 @@ Schedule::job(new SyncRecipesJob())
     ]);
 
 Schedule::job(new SyncMenusJob())
+    ->twiceDaily();
+
+Schedule::job(new CountryResourcesOrchestrationJob())
     ->twiceDaily();
 
 Schedule::job(new UpdateCountryStatisticsJob())

--- a/tests/Unit/Jobs/UpdateCountryStatisticsJobTest.php
+++ b/tests/Unit/Jobs/UpdateCountryStatisticsJobTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Jobs;
 
 use App\Enums\QueueEnum;
-use App\Jobs\UpdateCountryStatisticsJob;
+use App\Jobs\Country\UpdateCountryStatisticsJob;
 use App\Models\Allergen;
 use App\Models\Country;
 use App\Models\Cuisine;


### PR DESCRIPTION
- Introduce `ActivateCountryResourcesJob` to update active status of country resources based on recipe counts.
- Add `CountryResourcesOrchestrationJob` to dispatch activation jobs for all countries.
- Update existing `UpdateCountryStatisticsJob` to remove redundant activation logic.