### PR TITLE
chore(jobs): remove ShouldBeUnique from ImportRecipeJob and add unique lock duration

### DIFF
--- a/app/Jobs/Recipe/ImportRecipeJob.php
+++ b/app/Jobs/Recipe/ImportRecipeJob.php
@@ -33,7 +33,7 @@ use Illuminate\Support\Str;
  * @phpstan-import-type RecipeCuisine from RecipesResponse
  * @phpstan-import-type RecipeUtensil from RecipesResponse
  */
-class ImportRecipeJob implements ShouldBeUnique, ShouldQueue
+class ImportRecipeJob implements ShouldQueue
 {
     use Batchable;
     use Queueable;
@@ -62,6 +62,11 @@ class ImportRecipeJob implements ShouldBeUnique, ShouldQueue
     {
         return $this->country->id . '-' . $this->locale . '-' . $this->recipe['id'];
     }
+
+    /**
+     * The number of seconds after which the job's unique lock will be released.
+     */
+    public int $uniqueFor = 900;
 
     /**
      * Execute the job.

--- a/routes/console.php
+++ b/routes/console.php
@@ -8,6 +8,9 @@ use App\Jobs\Recipe\SyncRecipesJob;
 use Illuminate\Console\Scheduling\Schedule as ConsoleSchedule;
 use Illuminate\Support\Facades\Schedule;
 
+Schedule::command('horizon:snapshot')
+    ->everyFiveMinutes();
+
 Schedule::command('prune-expired-email-verifications')
     ->daily();
 


### PR DESCRIPTION
- Update `ImportRecipeJob` to no longer implement `ShouldBeUnique`.
- Set `uniqueFor` property to 900 seconds for job lock management.
- Add Horizon snapshot scheduling every 5 minutes.