### PR TITLE
feat(jobs): add `SyncMenuRecipesJob` and improve recipe fetching workflow in `FetchMenusJob`

### DIFF
--- a/app/Jobs/Menu/SyncMenuRecipesJob.php
+++ b/app/Jobs/Menu/SyncMenuRecipesJob.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Jobs\Menu;
+
+use App\Enums\QueueEnum;
+use App\Models\Menu;
+use App\Models\Recipe;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class SyncMenuRecipesJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param  list<string>  $hellofreshIds
+     */
+    public function __construct(
+        public Menu $menu,
+        public int $countryId,
+        public array $hellofreshIds,
+    ) {
+        $this->onQueue(QueueEnum::Import->value);
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $recipeIds = Recipe::where('country_id', $this->countryId)
+            ->whereIn('hellofresh_id', $this->hellofreshIds)
+            ->pluck('id')
+            ->toArray();
+
+        if ($recipeIds === []) {
+            return;
+        }
+
+        $this->menu->recipes()->sync($recipeIds);
+    }
+}

--- a/app/Jobs/Recipe/FetchRecipeJob.php
+++ b/app/Jobs/Recipe/FetchRecipeJob.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Jobs\Recipe;
+
+use App\Enums\QueueEnum;
+use App\Http\Clients\HelloFresh\HelloFreshClient;
+use App\Jobs\Concerns\HandlesApiFailuresTrait;
+use App\Models\Country;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+
+class FetchRecipeJob implements ShouldQueue
+{
+    use Batchable;
+    use HandlesApiFailuresTrait;
+    use Queueable;
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public int $tries = 3;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Country $country,
+        public string $locale,
+        public string $hellofreshId,
+    ) {
+        $this->onQueue(QueueEnum::HelloFresh->value);
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    public function handle(HelloFreshClient $client): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
+        try {
+            $recipeData = $client->getRecipe($this->country, $this->locale, $this->hellofreshId)->array();
+        } catch (ConnectionException|RequestException $exception) {
+            $this->handleApiFailure($exception);
+
+            return;
+        }
+
+        ImportRecipeJob::dispatch(
+            country: $this->country,
+            locale: $this->locale,
+            recipe: $recipeData,
+            ignoreActive: true,
+        );
+    }
+}


### PR DESCRIPTION
- Introduce `SyncMenuRecipesJob` for syncing menu recipes with database IDs.
- Add `FetchRecipeJob` to dynamically fetch missing recipes from the API.
- Refactor `FetchMenusJob` to batch-fetch missing recipes and leverage `SyncMenuRecipesJob`.