### PR TITLE
fix(modal): centralize and reuse default translations for confirmation modals

### DIFF
--- a/resources/views/components/confirmation-modal.blade.php
+++ b/resources/views/components/confirmation-modal.blade.php
@@ -1,11 +1,17 @@
 <flux:modal
     name="confirm-action"
     class="min-w-[22rem]"
-    x-data
+    x-data="{
+        defaults: {
+            title: @js(__('Confirm Action')),
+            message: @js(__('Are you sure?')),
+            confirm: @js(__('Confirm')),
+        }
+    }"
     x-on:confirm-action.window="
-        $el.querySelector('[data-confirm-title]').textContent = $event.detail.title || '{{ __('Confirm Action') }}';
-        $el.querySelector('[data-confirm-message]').textContent = $event.detail.message || '{{ __('Are you sure?') }}';
-        $el.querySelector('[data-confirm-button]').textContent = $event.detail.confirmText || '{{ __('Confirm') }}';
+        $el.querySelector('[data-confirm-title]').textContent = $event.detail.title || defaults.title;
+        $el.querySelector('[data-confirm-message]').textContent = $event.detail.message || defaults.message;
+        $el.querySelector('[data-confirm-button]').textContent = $event.detail.confirmText || defaults.confirm;
         window._confirmAction = $event.detail.onConfirm;
         $flux.modal('confirm-action').show();
     "

--- a/resources/views/web/livewire/shopping-list/shopping-list-index.blade.php
+++ b/resources/views/web/livewire/shopping-list/shopping-list-index.blade.php
@@ -2,6 +2,15 @@
   container
   class="space-y-section"
   x-data="{
+        translations: {
+            removeRecipe: @js(__('Remove Recipe')),
+            removeFromList: @js(__('Remove :name from shopping list?', ['name' => ''])),
+            remove: @js(__('Remove')),
+            clearShoppingList: @js(__('Clear Shopping List')),
+            removeAllRecipes: @js(__('Remove all recipes from your shopping list?')),
+            clearAll: @js(__('Clear All')),
+        },
+        bringUrl: @js(localized_route('localized.shopping-list.bring')),
         initialized: false,
         init() {
             this.$nextTick(() => {
@@ -24,9 +33,9 @@
         confirmRemoveRecipe(recipeId, recipeName) {
             window.dispatchEvent(new CustomEvent('confirm-action', {
                 detail: {
-                    title: '{{ __('Remove Recipe') }}',
-                    message: '{{ __('Remove :name from shopping list?', ['name' => '']) }}' + recipeName,
-                    confirmText: '{{ __('Remove') }}',
+                    title: this.translations.removeRecipe,
+                    message: this.translations.removeFromList + recipeName,
+                    confirmText: this.translations.remove,
                     onConfirm: () => $store.shoppingList.remove(recipeId)
                 }
             }));
@@ -34,9 +43,9 @@
         confirmClearAll() {
             window.dispatchEvent(new CustomEvent('confirm-action', {
                 detail: {
-                    title: '{{ __('Clear Shopping List') }}',
-                    message: '{{ __('Remove all recipes from your shopping list?') }}',
-                    confirmText: '{{ __('Clear All') }}',
+                    title: this.translations.clearShoppingList,
+                    message: this.translations.removeAllRecipes,
+                    confirmText: this.translations.clearAll,
                     onConfirm: () => $store.shoppingList.clear()
                 }
             }));
@@ -55,12 +64,8 @@
             const recipesParam = items.join(',');
             const servingsParam = items.map(id => id + ':' + (servings[id] || 2)).join(',');
 
-            const bringUrl = '{{ localized_route('localized.shopping-list.bring') }}'
-                + '?recipes=' + encodeURIComponent(recipesParam)
-                + '&servings=' + encodeURIComponent(servingsParam);
-
             const url = 'https://api.getbring.com/rest/bringrecipes/deeplink'
-                + '?url=' + encodeURIComponent(bringUrl)
+                + '?url=' + encodeURIComponent(this.bringUrl + '?recipes=' + encodeURIComponent(recipesParam) + '&servings=' + encodeURIComponent(servingsParam))
                 + '&source=web';
 
             window.open(url, '_blank');


### PR DESCRIPTION
- Add reusable `defaults` and `translations` objects in components for cleaner translation handling.
- Refactor confirmation modal logic to use these centralized translation defaults.
- Update event handlers in shopping list views to leverage new translation structure for consistency.