### PR TITLE
fix(translations): centralize default translations in views

### DIFF
--- a/resources/views/components/confirmation-modal.blade.php
+++ b/resources/views/components/confirmation-modal.blade.php
@@ -1,13 +1,14 @@
+@php
+    $defaults = [
+        'title' => __('Confirm Action'),
+        'message' => __('Are you sure?'),
+        'confirm' => __('Confirm'),
+    ];
+@endphp
 <flux:modal
     name="confirm-action"
     class="min-w-[22rem]"
-    x-data="{
-        defaults: {
-            title: @js(__('Confirm Action')),
-            message: @js(__('Are you sure?')),
-            confirm: @js(__('Confirm')),
-        }
-    }"
+    x-data="{ defaults: {{ Js::from($defaults) }} }"
     x-on:confirm-action.window="
         $el.querySelector('[data-confirm-title]').textContent = $event.detail.title || defaults.title;
         $el.querySelector('[data-confirm-message]').textContent = $event.detail.message || defaults.message;

--- a/resources/views/web/livewire/shopping-list/shopping-list-index.blade.php
+++ b/resources/views/web/livewire/shopping-list/shopping-list-index.blade.php
@@ -1,16 +1,21 @@
+@php
+    $jsConfig = [
+        'translations' => [
+            'removeRecipe' => __('Remove Recipe'),
+            'removeFromList' => __('Remove :name from shopping list?', ['name' => '']),
+            'remove' => __('Remove'),
+            'clearShoppingList' => __('Clear Shopping List'),
+            'removeAllRecipes' => __('Remove all recipes from your shopping list?'),
+            'clearAll' => __('Clear All'),
+        ],
+        'bringUrl' => localized_route('localized.shopping-list.bring'),
+    ];
+@endphp
 <flux:main
   container
   class="space-y-section"
   x-data="{
-        translations: {
-            removeRecipe: @js(__('Remove Recipe')),
-            removeFromList: @js(__('Remove :name from shopping list?', ['name' => ''])),
-            remove: @js(__('Remove')),
-            clearShoppingList: @js(__('Clear Shopping List')),
-            removeAllRecipes: @js(__('Remove all recipes from your shopping list?')),
-            clearAll: @js(__('Clear All')),
-        },
-        bringUrl: @js(localized_route('localized.shopping-list.bring')),
+        ...{{ Js::from($jsConfig) }},
         initialized: false,
         init() {
             this.$nextTick(() => {


### PR DESCRIPTION
- Extract translation defaults into reusable PHP variables in confirmation modal and shopping list views.
- Use `Js::from()` for cleaner and consistent translation handling in Alpine `x-data` structures.