### PR TITLE
feat(jobs): add `SyncMenuRecipesJob` and improve recipe fetching workflow in `FetchMenusJob`

### DIFF
--- a/app/Jobs/Menu/FetchMenusJob.php
+++ b/app/Jobs/Menu/FetchMenusJob.php
@@ -140,10 +140,15 @@ class FetchMenusJob implements ShouldQueue
             );
         }
 
+        // Extract primitive values for serializable closure
+        $menuId = $menu->id;
+        $countryId = $this->country->id;
+        $recipeIds = $menuData['recipe_ids'];
+
         Bus::batch($jobs)
             ->name(sprintf('Fetch missing recipes for menu %d', $menu->year_week))
             ->onQueue(QueueEnum::HelloFresh->value)
-            ->then(fn () => SyncMenuRecipesJob::dispatch($menu, $this->country->id, $menuData['recipe_ids']))
+            ->then(fn () => SyncMenuRecipesJob::dispatch($menuId, $countryId, $recipeIds))
             ->dispatch();
     }
 }

--- a/app/Jobs/Menu/SyncMenuRecipesJob.php
+++ b/app/Jobs/Menu/SyncMenuRecipesJob.php
@@ -18,7 +18,7 @@ class SyncMenuRecipesJob implements ShouldQueue
      * @param  list<string>  $hellofreshIds
      */
     public function __construct(
-        public Menu $menu,
+        public int $menuId,
         public int $countryId,
         public array $hellofreshIds,
     ) {
@@ -30,6 +30,12 @@ class SyncMenuRecipesJob implements ShouldQueue
      */
     public function handle(): void
     {
+        $menu = Menu::find($this->menuId);
+
+        if ($menu === null) {
+            return;
+        }
+
         $recipeIds = Recipe::where('country_id', $this->countryId)
             ->whereIn('hellofresh_id', $this->hellofreshIds)
             ->pluck('id')
@@ -39,6 +45,6 @@ class SyncMenuRecipesJob implements ShouldQueue
             return;
         }
 
-        $this->menu->recipes()->sync($recipeIds);
+        $menu->recipes()->sync($recipeIds);
     }
 }


### PR DESCRIPTION
- Introduce `SyncMenuRecipesJob` for syncing menu recipes with database IDs.
- Add `FetchRecipeJob` to dynamically fetch missing recipes from the API.
- Refactor `FetchMenusJob` to batch-fetch missing recipes and leverage `SyncMenuRecipesJob`.