### PR TITLE
feat(portal): add Changelog viewer with markdown rendering

### DIFF
--- a/app/Livewire/Portal/Changelog.php
+++ b/app/Livewire/Portal/Changelog.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Livewire\Portal;
+
+use App\Support\Markdown\FluxRenderer;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\File;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\Table\TableExtension;
+use League\CommonMark\Parser\MarkdownParser;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('portal::components.layouts.app')]
+class Changelog extends Component
+{
+    /**
+     * Get the rendered changelog content.
+     */
+    #[Computed]
+    public function content(): string
+    {
+        $path = base_path('CHANGELOG.md');
+
+        if (! File::exists($path)) {
+            return '';
+        }
+
+        $markdown = File::get($path);
+
+        $environment = new Environment();
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new TableExtension());
+
+        $parser = new MarkdownParser($environment);
+        $document = $parser->parse($markdown);
+
+        return new FluxRenderer()->render($document);
+    }
+
+    public function render(): View
+    {
+        return view('portal::livewire.changelog')->title('Changelog');
+    }
+}

--- a/resources/views/flux/icon/scroll-text.blade.php
+++ b/resources/views/flux/icon/scroll-text.blade.php
@@ -1,0 +1,46 @@
+@blaze
+
+{{-- Credit: Lucide (https://lucide.dev) --}}
+
+@props([
+    'variant' => 'outline',
+])
+
+@php
+if ($variant === 'solid') {
+    throw new \Exception('The "solid" variant is not supported in Lucide.');
+}
+
+$classes = Flux::classes('shrink-0')
+    ->add(match($variant) {
+        'outline' => '[:where(&)]:size-6',
+        'solid' => '[:where(&)]:size-6',
+        'mini' => '[:where(&)]:size-5',
+        'micro' => '[:where(&)]:size-4',
+    });
+
+$strokeWidth = match ($variant) {
+    'outline' => 2,
+    'mini' => 2.25,
+    'micro' => 2.5,
+};
+@endphp
+
+<svg
+    {{ $attributes->class($classes) }}
+    data-flux-icon
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="{{ $strokeWidth }}"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    data-slot="icon"
+>
+  <path d="M15 12h-5" />
+  <path d="M15 8h-5" />
+  <path d="M19 17V5a2 2 0 0 0-2-2H4" />
+  <path d="M8 21h12a2 2 0 0 0 2-2v-1a1 1 0 0 0-1-1H11a1 1 0 0 0-1 1v1a2 2 0 1 1-4 0V5a2 2 0 1 0-4 0v2a1 1 0 0 0 1 1h3" />
+</svg>

--- a/resources/views/portal/livewire/changelog.blade.php
+++ b/resources/views/portal/livewire/changelog.blade.php
@@ -1,0 +1,7 @@
+<div class="space-y-section">
+  <flux:heading size="xl">Changelog</flux:heading>
+
+  <flux:card class="flex flex-col gap-section">
+    {!! $this->content !!}
+  </flux:card>
+</div>


### PR DESCRIPTION
- Introduced a Livewire component for rendering the Changelog page.
- Implemented markdown parsing and rendering using `FluxRenderer`.
- Added views for displaying the Changelog content in the portal.