### PR TITLE
feat(statistics): include ingredient country codes and flags in top ingredients table

### DIFF
--- a/app/Livewire/Portal/Statistic.php
+++ b/app/Livewire/Portal/Statistic.php
@@ -142,15 +142,16 @@ class Statistic extends Component
     /**
      * Get top ingredients by recipe count.
      *
-     * @return Collection<int, object{name: string, recipes_count: int}>
+     * @return Collection<int, object{name: string, country_code: string, recipes_count: int}>
      */
     #[Computed]
     public function topIngredients(): Collection
     {
         return Cache::remember('portal_top_ingredients', 3600, static fn (): Collection => DB::table('ingredients')
             ->join('ingredient_recipe', 'ingredients.id', '=', 'ingredient_recipe.ingredient_id')
-            ->select('ingredients.name', DB::raw('COUNT(ingredient_recipe.recipe_id) as recipes_count'))
-            ->groupBy('ingredients.id', 'ingredients.name')
+            ->join('countries', 'ingredients.country_id', '=', 'countries.id')
+            ->select('ingredients.name', 'countries.code as country_code', DB::raw('COUNT(ingredient_recipe.recipe_id) as recipes_count'))
+            ->groupBy('ingredients.id', 'ingredients.name', 'countries.code')
             ->orderByDesc('recipes_count')
             ->limit(10)
             ->get());

--- a/resources/views/portal/livewire/statistic/partials/top-lists.blade.php
+++ b/resources/views/portal/livewire/statistic/partials/top-lists.blade.php
@@ -10,7 +10,10 @@
       <flux:table.rows>
         @foreach($this->topIngredients as $ingredient)
           <flux:table.row wire:key="ingredient-{{ $loop->index }}">
-            <flux:table.cell class="truncate max-w-48">{{ json_decode($ingredient->name)->en ?? $ingredient->name }}</flux:table.cell>
+            <flux:table.cell class="truncate max-w-48">
+              <span title="{{ $ingredient->country_code }}">{{ Str::countryFlag($ingredient->country_code) }}</span>
+              {{ json_decode($ingredient->name)->en ?? $ingredient->name }}
+            </flux:table.cell>
             <flux:table.cell align="end" class="tabular-nums">{{ number_format($ingredient->recipes_count) }}</flux:table.cell>
           </flux:table.row>
         @endforeach


### PR DESCRIPTION
- Added `country_code` to `topIngredients` computation for better context.
- Displayed country flags next to ingredient names in the stats table for enhanced visualization.