### PR TITLE
feat(data-maintenance): add ingredient name cleanup command

### DIFF
--- a/app/Console/Commands/DataMaintenance/CleanupIngredientNamesCommand.php
+++ b/app/Console/Commands/DataMaintenance/CleanupIngredientNamesCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Console\Commands\DataMaintenance;
+
+use App\Models\Ingredient;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'data-maintenance:cleanup-ingredient-names')]
+class CleanupIngredientNamesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'data-maintenance:cleanup-ingredient-names
+                            {--dry-run : Show what would be cleaned without making changes}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove trailing asterisks from ingredient names';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->components->info('Running in dry-run mode. No changes will be made.');
+        }
+
+        $ingredients = Ingredient::query()
+            ->whereRaw("name::text LIKE '%*%'")
+            ->get();
+
+        if ($ingredients->isEmpty()) {
+            $this->components->info('No ingredients with asterisks found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->components->info("Found {$ingredients->count()} ingredients with asterisks.");
+
+        $updated = 0;
+
+        foreach ($ingredients as $ingredient) {
+            $names = $ingredient->getTranslations('name');
+            $changed = false;
+
+            foreach ($names as $locale => $name) {
+                $cleaned = rtrim($name, '*');
+
+                if ($cleaned !== $name) {
+                    $names[$locale] = $cleaned;
+                    $changed = true;
+
+                    $this->components->twoColumnDetail(
+                        "<fg=yellow>{$locale}</>: {$name}",
+                        $cleaned
+                    );
+                }
+            }
+
+            if ($changed) {
+                if (! $dryRun) {
+                    $ingredient->setTranslations('name', $names)->save();
+                }
+                $updated++;
+            }
+        }
+
+        $action = $dryRun ? 'Would update' : 'Updated';
+        $this->components->info("{$action} {$updated} ingredients.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Providers/MacroServiceProvider.php
+++ b/app/Providers/MacroServiceProvider.php
@@ -29,7 +29,7 @@ class MacroServiceProvider extends ServiceProvider
 
         Str::macro(
             'normalizeNameStrict',
-            fn (string $value): string => Str::ucfirst(Str::squish(Str::before($value, ' (')))
+            fn (string $value): string => Str::ucfirst(Str::squish(rtrim(Str::before($value, ' ('), '*')))
         );
 
         Str::macro(


### PR DESCRIPTION
- Introduced `CleanupIngredientNamesCommand` to remove trailing asterisks from ingredient names.
- Updated `normalizeNameStrict` macro to trim trailing asterisks for consistency.