### PR TITLE
feat(statistics): include country codes and flags in top tags and cuisines

### DIFF
--- a/app/Console/Commands/DataMaintenance/CleanupIngredientNamesCommand.php
+++ b/app/Console/Commands/DataMaintenance/CleanupIngredientNamesCommand.php
@@ -35,9 +35,7 @@ class CleanupIngredientNamesCommand extends Command
             $this->components->info('Running in dry-run mode. No changes will be made.');
         }
 
-        $ingredients = Ingredient::query()
-            ->whereRaw("name::text LIKE '%*%'")
-            ->get();
+        $ingredients = Ingredient::whereRaw("name::text LIKE '%*%'")->get();
 
         if ($ingredients->isEmpty()) {
             $this->components->info('No ingredients with asterisks found.');
@@ -45,7 +43,7 @@ class CleanupIngredientNamesCommand extends Command
             return self::SUCCESS;
         }
 
-        $this->components->info("Found {$ingredients->count()} ingredients with asterisks.");
+        $this->components->info(sprintf('Found %d ingredients with asterisks.', $ingredients->count()));
 
         $updated = 0;
 
@@ -54,14 +52,14 @@ class CleanupIngredientNamesCommand extends Command
             $changed = false;
 
             foreach ($names as $locale => $name) {
-                $cleaned = rtrim($name, '*');
+                $cleaned = rtrim((string) $name, '*');
 
                 if ($cleaned !== $name) {
                     $names[$locale] = $cleaned;
                     $changed = true;
 
                     $this->components->twoColumnDetail(
-                        "<fg=yellow>{$locale}</>: {$name}",
+                        sprintf('<fg=yellow>%s</>: %s', $locale, $name),
                         $cleaned
                     );
                 }
@@ -71,12 +69,13 @@ class CleanupIngredientNamesCommand extends Command
                 if (! $dryRun) {
                     $ingredient->setTranslations('name', $names)->save();
                 }
+
                 $updated++;
             }
         }
 
         $action = $dryRun ? 'Would update' : 'Updated';
-        $this->components->info("{$action} {$updated} ingredients.");
+        $this->components->info(sprintf('%s %d ingredients.', $action, $updated));
 
         return self::SUCCESS;
     }

--- a/app/Livewire/Portal/Statistic.php
+++ b/app/Livewire/Portal/Statistic.php
@@ -160,15 +160,16 @@ class Statistic extends Component
     /**
      * Get top tags by recipe count.
      *
-     * @return Collection<int, object{name: string, recipes_count: int}>
+     * @return Collection<int, object{name: string, country_code: string, recipes_count: int}>
      */
     #[Computed]
     public function topTags(): Collection
     {
         return Cache::remember('portal_top_tags', 3600, static fn (): Collection => DB::table('tags')
             ->join('recipe_tag', 'tags.id', '=', 'recipe_tag.tag_id')
-            ->select('tags.name', DB::raw('COUNT(recipe_tag.recipe_id) as recipes_count'))
-            ->groupBy('tags.id', 'tags.name')
+            ->join('countries', 'tags.country_id', '=', 'countries.id')
+            ->select('tags.name', 'countries.code as country_code', DB::raw('COUNT(recipe_tag.recipe_id) as recipes_count'))
+            ->groupBy('tags.id', 'tags.name', 'countries.code')
             ->orderByDesc('recipes_count')
             ->limit(10)
             ->get());
@@ -177,15 +178,16 @@ class Statistic extends Component
     /**
      * Get top cuisines by recipe count.
      *
-     * @return Collection<int, object{name: string, recipes_count: int}>
+     * @return Collection<int, object{name: string, country_code: string, recipes_count: int}>
      */
     #[Computed]
     public function topCuisines(): Collection
     {
         return Cache::remember('portal_top_cuisines', 3600, static fn (): Collection => DB::table('cuisines')
             ->join('cuisine_recipe', 'cuisines.id', '=', 'cuisine_recipe.cuisine_id')
-            ->select('cuisines.name', DB::raw('COUNT(cuisine_recipe.recipe_id) as recipes_count'))
-            ->groupBy('cuisines.id', 'cuisines.name')
+            ->join('countries', 'cuisines.country_id', '=', 'countries.id')
+            ->select('cuisines.name', 'countries.code as country_code', DB::raw('COUNT(cuisine_recipe.recipe_id) as recipes_count'))
+            ->groupBy('cuisines.id', 'cuisines.name', 'countries.code')
             ->orderByDesc('recipes_count')
             ->limit(10)
             ->get());

--- a/resources/views/portal/livewire/statistic/partials/top-lists.blade.php
+++ b/resources/views/portal/livewire/statistic/partials/top-lists.blade.php
@@ -31,7 +31,10 @@
       <flux:table.rows>
         @foreach($this->topTags as $tag)
           <flux:table.row wire:key="tag-{{ $loop->index }}">
-            <flux:table.cell class="truncate max-w-48">{{ json_decode($tag->name)->en ?? $tag->name }}</flux:table.cell>
+            <flux:table.cell class="truncate max-w-48">
+              <span title="{{ $tag->country_code }}">{{ Str::countryFlag($tag->country_code) }}</span>
+              {{ json_decode($tag->name)->en ?? $tag->name }}
+            </flux:table.cell>
             <flux:table.cell align="end" class="tabular-nums">{{ number_format($tag->recipes_count) }}</flux:table.cell>
           </flux:table.row>
         @endforeach
@@ -49,7 +52,10 @@
       <flux:table.rows>
         @foreach($this->topCuisines as $cuisine)
           <flux:table.row wire:key="cuisine-{{ $loop->index }}">
-            <flux:table.cell class="truncate max-w-48">{{ json_decode($cuisine->name)->en ?? $cuisine->name }}</flux:table.cell>
+            <flux:table.cell class="truncate max-w-48">
+              <span title="{{ $cuisine->country_code }}">{{ Str::countryFlag($cuisine->country_code) }}</span>
+              {{ json_decode($cuisine->name)->en ?? $cuisine->name }}
+            </flux:table.cell>
             <flux:table.cell align="end" class="tabular-nums">{{ number_format($cuisine->recipes_count) }}</flux:table.cell>
           </flux:table.row>
         @endforeach


### PR DESCRIPTION
- Added `country_code` to `topTags` and `topCuisines` computations for better context.
- Displayed country flags alongside tag and cuisine names in the stats table for enhanced visualization.