### PR TITLE
feat(data-maintenance): add command to cleanup duplicate tags

### DIFF
--- a/app/Console/Commands/DataMaintenance/CleanupDuplicateAllergensCommand.php
+++ b/app/Console/Commands/DataMaintenance/CleanupDuplicateAllergensCommand.php
@@ -4,13 +4,22 @@ declare(strict_types=1);
 
 namespace App\Console\Commands\DataMaintenance;
 
+use App\Console\Commands\DataMaintenance\Contracts\DataMaintenanceCommandInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'data-maintenance:cleanup-duplicate-allergens')]
-class CleanupDuplicateAllergensCommand extends Command
+class CleanupDuplicateAllergensCommand extends Command implements DataMaintenanceCommandInterface
 {
+    /**
+     * Get the order in which this command should run.
+     */
+    public function getExecutionOrder(): int
+    {
+        return 30;
+    }
+
     /**
      * The name and signature of the console command.
      *

--- a/app/Console/Commands/DataMaintenance/CleanupDuplicateTagsCommand.php
+++ b/app/Console/Commands/DataMaintenance/CleanupDuplicateTagsCommand.php
@@ -4,13 +4,22 @@ declare(strict_types=1);
 
 namespace App\Console\Commands\DataMaintenance;
 
+use App\Console\Commands\DataMaintenance\Contracts\DataMaintenanceCommandInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'data-maintenance:cleanup-duplicate-tags')]
-class CleanupDuplicateTagsCommand extends Command
+class CleanupDuplicateTagsCommand extends Command implements DataMaintenanceCommandInterface
 {
+    /**
+     * Get the order in which this command should run.
+     */
+    public function getExecutionOrder(): int
+    {
+        return 40;
+    }
+
     /**
      * The name and signature of the console command.
      *

--- a/app/Console/Commands/DataMaintenance/CleanupIngredientNamesCommand.php
+++ b/app/Console/Commands/DataMaintenance/CleanupIngredientNamesCommand.php
@@ -1,14 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Console\Commands\DataMaintenance;
 
+use App\Console\Commands\DataMaintenance\Contracts\DataMaintenanceCommandInterface;
 use App\Models\Ingredient;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'data-maintenance:cleanup-ingredient-names')]
-class CleanupIngredientNamesCommand extends Command
+class CleanupIngredientNamesCommand extends Command implements DataMaintenanceCommandInterface
 {
+    /**
+     * Get the order in which this command should run.
+     */
+    public function getExecutionOrder(): int
+    {
+        return 10; // Run early - clean names before merging
+    }
+
     /**
      * The name and signature of the console command.
      *

--- a/app/Console/Commands/DataMaintenance/Contracts/DataMaintenanceCommandInterface.php
+++ b/app/Console/Commands/DataMaintenance/Contracts/DataMaintenanceCommandInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\DataMaintenance\Contracts;
+
+/**
+ * Interface for data maintenance commands that can be run via the master cleanup command.
+ *
+ * Commands implementing this interface will be automatically discovered and executed
+ * by the `data-maintenance:run-all` command.
+ */
+interface DataMaintenanceCommandInterface
+{
+    /**
+     * Get the order in which this command should run.
+     * Lower numbers run first.
+     */
+    public function getExecutionOrder(): int;
+}

--- a/app/Console/Commands/DataMaintenance/MergeDuplicateIngredientsCommand.php
+++ b/app/Console/Commands/DataMaintenance/MergeDuplicateIngredientsCommand.php
@@ -4,13 +4,22 @@ declare(strict_types=1);
 
 namespace App\Console\Commands\DataMaintenance;
 
+use App\Console\Commands\DataMaintenance\Contracts\DataMaintenanceCommandInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'data-maintenance:merge-duplicate-ingredients')]
-class MergeDuplicateIngredientsCommand extends Command
+class MergeDuplicateIngredientsCommand extends Command implements DataMaintenanceCommandInterface
 {
+    /**
+     * Get the order in which this command should run.
+     */
+    public function getExecutionOrder(): int
+    {
+        return 20; // Run after name cleanup
+    }
+
     /**
      * The name and signature of the console command.
      *

--- a/app/Console/Commands/DataMaintenance/RunAllDataMaintenanceCommand.php
+++ b/app/Console/Commands/DataMaintenance/RunAllDataMaintenanceCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\DataMaintenance;
+
+use App\Console\Commands\DataMaintenance\Contracts\DataMaintenanceCommandInterface;
+use Illuminate\Console\Application as Artisan;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+
+#[AsCommand(name: 'data-maintenance:run-all')]
+class RunAllDataMaintenanceCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'data-maintenance:run-all
+                            {--dry-run : Show what would be done without making changes}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run all data maintenance commands in order';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->components->warn('DRY RUN - No changes will be made');
+        }
+
+        $commands = $this->discoverMaintenanceCommands();
+
+        if ($commands === []) {
+            $this->components->info('No data maintenance commands found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->components->info(sprintf('Found %d data maintenance commands to run.', count($commands)));
+        $this->newLine();
+
+        $failed = 0;
+
+        foreach ($commands as $command) {
+            $commandName = $command->getName();
+
+            if ($commandName === null) {
+                continue;
+            }
+
+            $this->components->task($commandName, function () use ($commandName, $dryRun, &$failed): void {
+                $options = $dryRun ? ['--dry-run' => true] : [];
+                $exitCode = $this->callSilently($commandName, $options);
+
+                if ($exitCode !== self::SUCCESS) {
+                    $failed++;
+                }
+            });
+        }
+
+        $this->newLine();
+
+        if ($failed > 0) {
+            $this->components->error(sprintf('%d command(s) failed.', $failed));
+
+            return self::FAILURE;
+        }
+
+        $this->components->info('All data maintenance commands completed successfully.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Discover all commands implementing DataMaintenanceCommandInterface.
+     *
+     * @return list<DataMaintenanceCommandInterface&SymfonyCommand>
+     */
+    protected function discoverMaintenanceCommands(): array
+    {
+        /** @var Artisan $artisan */
+        $artisan = $this->getApplication();
+
+        $commands = [];
+
+        foreach ($artisan->all() as $command) {
+            if ($command instanceof DataMaintenanceCommandInterface) {
+                $commands[] = $command;
+            }
+        }
+
+        // Sort by execution order
+        usort($commands, fn (DataMaintenanceCommandInterface $commandA, DataMaintenanceCommandInterface $commandB): int => $commandA->getExecutionOrder() <=> $commandB->getExecutionOrder());
+
+        return $commands;
+    }
+}


### PR DESCRIPTION
- Introduced `CleanupDuplicateTagsCommand` to identify and merge duplicate tags by name and country.
- Preserves `active` and `display_label` flags, and consolidates `hellofresh_ids` from duplicates.
- Includes a `--dry-run` option for testing changes without applying them.
- Moves pivot entries and deletes redundant tags after merging.