### PR TITLE
feat(users): add country column with sorting and flags in User Index

### DIFF
--- a/resources/views/portal/components/layouts/app.blade.php
+++ b/resources/views/portal/components/layouts/app.blade.php
@@ -105,7 +105,7 @@
       {{ config('app.name') }}
     </flux:sidebar.item>
     @if(auth()->user()?->admin)
-      <flux:sidebar.item icon="laravel-horizon" :href="config('app.url').'/'.config('horizon.path')" :current="false">
+      <flux:sidebar.item icon="laravel-horizon" :href="config('app.url').'/'.config('horizon.path')" :current="false" target="_blank">
         Horizon
       </flux:sidebar.item>
     @endif

--- a/resources/views/portal/livewire/admin/user-index.blade.php
+++ b/resources/views/portal/livewire/admin/user-index.blade.php
@@ -51,6 +51,7 @@
         <flux:table.column sortable :sorted="$sortBy === 'id'" :direction="$sortDirection" wire:click="sort('id')">ID</flux:table.column>
         <flux:table.column sortable :sorted="$sortBy === 'name'" :direction="$sortDirection" wire:click="sort('name')">User</flux:table.column>
         <flux:table.column class="ui-text-subtle">Status</flux:table.column>
+        <flux:table.column sortable :sorted="$sortBy === 'country_code'" :direction="$sortDirection" wire:click="sort('country_code')">Country</flux:table.column>
         <flux:table.column sortable :sorted="$sortBy === 'tokens_count'" :direction="$sortDirection" wire:click="sort('tokens_count')">Tokens</flux:table.column>
         <flux:table.column sortable :sorted="$sortBy === 'active_at'" :direction="$sortDirection" wire:click="sort('active_at')">Last Active</flux:table.column>
         <flux:table.column sortable :sorted="$sortBy === 'created_at'" :direction="$sortDirection" wire:click="sort('created_at')">Registered</flux:table.column>
@@ -84,6 +85,13 @@
               @endif
             </flux:table.cell>
             <flux:table.cell>
+              @if($user->country_code)
+                <span title="{{ $user->countryName() }}">{{ $user->countryFlag() }} {{ $user->country_code }}</span>
+              @else
+                <flux:text variant="subtle">—</flux:text>
+              @endif
+            </flux:table.cell>
+            <flux:table.cell>
               <flux:badge size="sm">{{ $user->tokens_count }}</flux:badge>
             </flux:table.cell>
             <flux:table.cell align="right">
@@ -104,7 +112,7 @@
           </flux:table.row>
         @empty
           <flux:table.row>
-            <flux:table.cell colspan="7" class="text-center py-section">
+            <flux:table.cell colspan="8" class="text-center py-section">
               <flux:text variant="subtle">No users found.</flux:text>
             </flux:table.cell>
           </flux:table.row>

--- a/resources/views/portal/livewire/admin/user-show.blade.php
+++ b/resources/views/portal/livewire/admin/user-show.blade.php
@@ -1,19 +1,21 @@
 <div class="space-y-section">
+    <flux:breadcrumbs>
+        <flux:breadcrumbs.item :href="route('portal.admin.users')" wire:navigate>Users</flux:breadcrumbs.item>
+        <flux:breadcrumbs.item>{{ $user->name }}</flux:breadcrumbs.item>
+    </flux:breadcrumbs>
+
     {{-- Header --}}
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-section">
-        <div class="flex items-center gap-section">
-            <flux:button icon="arrow-left" variant="ghost" :href="route('portal.admin.users')" wire:navigate />
-            <div class="flex items-center gap-ui">
-                <flux:avatar name="{{ $user->name }}" size="lg" />
-                <div>
-                    <flux:heading size="xl" class="flex items-center gap-ui">
-                        {{ $user->name }}
-                        @if($user->admin)
-                            <flux:badge color="blue" size="sm">Admin</flux:badge>
-                        @endif
-                    </flux:heading>
-                    <flux:text variant="subtle">{{ $user->email }}</flux:text>
-                </div>
+        <div class="flex items-center gap-ui">
+            <flux:avatar name="{{ $user->name }}" size="lg" />
+            <div>
+                <flux:heading size="xl" class="flex items-center gap-ui">
+                    {{ $user->name }}
+                    @if($user->admin)
+                        <flux:badge color="blue" size="sm">Admin</flux:badge>
+                    @endif
+                </flux:heading>
+                <flux:text variant="subtle">{{ $user->email }}</flux:text>
             </div>
         </div>
         <flux:select wire:model.live="period" variant="listbox" class="w-full sm:w-40">


### PR DESCRIPTION
- Introduced a sortable "Country" column in the User Index table to display country codes and flags.
- Updated empty state column span for alignment.
- Added breadcrumbs navigation to the User Show view for improved usability.
- Set Horizon link to open in a new tab for admin users.