### PR TITLE
feat(tags): add loader icon to tags with wire:loading state

### DIFF
--- a/resources/views/flux/icon/loader-circle.blade.php
+++ b/resources/views/flux/icon/loader-circle.blade.php
@@ -1,0 +1,43 @@
+@blaze
+
+{{-- Credit: Lucide (https://lucide.dev) --}}
+
+@props([
+    'variant' => 'outline',
+])
+
+@php
+if ($variant === 'solid') {
+    throw new \Exception('The "solid" variant is not supported in Lucide.');
+}
+
+$classes = Flux::classes('shrink-0')
+    ->add(match($variant) {
+        'outline' => '[:where(&)]:size-6',
+        'solid' => '[:where(&)]:size-6',
+        'mini' => '[:where(&)]:size-5',
+        'micro' => '[:where(&)]:size-4',
+    });
+
+$strokeWidth = match ($variant) {
+    'outline' => 2,
+    'mini' => 2.25,
+    'micro' => 2.5,
+};
+@endphp
+
+<svg
+    {{ $attributes->class($classes) }}
+    data-flux-icon
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="{{ $strokeWidth }}"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    data-slot="icon"
+>
+  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+</svg>

--- a/resources/views/web/components/recipes/recipe-card.blade.php
+++ b/resources/views/web/components/recipes/recipe-card.blade.php
@@ -102,10 +102,16 @@
               x-on:click.stop="$wire.toggleTag({{ $tag->id }})"
               as="button"
               :color="$isActive ? 'lime' : 'zinc'"
-              :icon="$isActive ? 'check' : 'plus'"
               icon:variant="micro"
               size="sm"
-            >{{ $tag->name }}</flux:badge>
+              wire:loading.attr="disabled"
+              wire:target="toggleTag({{ $tag->id }})"
+            >
+              <flux:icon.loader-circle variant="micro" class="animate-spin" wire:loading wire:target="toggleTag({{ $tag->id }})" />
+              <flux:icon.check variant="micro" wire:loading.remove wire:target="toggleTag({{ $tag->id }})" @class(['hidden' => !$isActive]) />
+              <flux:icon.plus variant="micro" wire:loading.remove wire:target="toggleTag({{ $tag->id }})" @class(['hidden' => $isActive]) />
+              {{ $tag->name }}
+            </flux:badge>
           @endforeach
         </div>
       @endif
@@ -181,10 +187,16 @@
               x-on:click.stop="$wire.toggleTag({{ $tag->id }})"
               as="button"
               :color="$isActive ? 'lime' : 'zinc'"
-              :icon="$isActive ? 'check' : 'plus'"
               icon:variant="micro"
               size="sm"
-            >{{ $tag->name }}</flux:badge>
+              wire:loading.attr="disabled"
+              wire:target="toggleTag({{ $tag->id }})"
+            >
+              <flux:icon.loader-circle variant="micro" class="animate-spin" wire:loading wire:target="toggleTag({{ $tag->id }})" />
+              <flux:icon.check variant="micro" wire:loading.remove wire:target="toggleTag({{ $tag->id }})" @class(['hidden' => !$isActive]) />
+              <flux:icon.plus variant="micro" wire:loading.remove wire:target="toggleTag({{ $tag->id }})" @class(['hidden' => $isActive]) />
+              {{ $tag->name }}
+            </flux:badge>
           @endforeach
         </div>
       @endif


### PR DESCRIPTION
- Introduced `loader-circle` icon component for displaying a spinning loader.
- Updated tag rendering to show loader while `toggleTag` is processing.
- Replaced conditional icons (`check` and `plus`) with `wire:loading.remove` logic for cleaner state management.