### PR TITLE
feat(statistics): add users by country metric with grouped data display

### DIFF
--- a/app/Livewire/Portal/Statistic.php
+++ b/app/Livewire/Portal/Statistic.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use stdClass;
 
 #[Layout('portal::components.layouts.app')]
 class Statistic extends Component
@@ -150,6 +151,17 @@ class Statistic extends Component
     public function userEngagement(): array
     {
         return $this->statistics()->userEngagement();
+    }
+
+    /**
+     * Get user counts grouped by country.
+     *
+     * @return Collection<int, stdClass>
+     */
+    #[Computed]
+    public function usersByCountry(): Collection
+    {
+        return $this->statistics()->usersByCountry();
     }
 
     /**

--- a/app/Services/Portal/StatisticsService.php
+++ b/app/Services/Portal/StatisticsService.php
@@ -39,6 +39,7 @@ class StatisticsService
         'portal_top_cuisines',
         'portal_recipes_per_month',
         'portal_user_engagement',
+        'portal_users_by_country',
         'portal_avg_prep_times',
         'portal_data_health',
     ];
@@ -70,6 +71,7 @@ class StatisticsService
         $this->topCuisines();
         $this->recipesPerMonth();
         $this->userEngagement();
+        $this->usersByCountry();
         $this->avgPrepTimesByCountry();
         $this->dataHealth();
     }
@@ -249,6 +251,20 @@ class StatisticsService
                 'total_recipes_in_lists' => $totalRecipesInLists,
             ];
         });
+    }
+
+    /**
+     * Get user counts grouped by country.
+     *
+     * @return Collection<int, stdClass>
+     */
+    public function usersByCountry(): Collection
+    {
+        return Cache::remember('portal_users_by_country', $this->cacheTtl, static fn (): Collection => DB::table('users')
+            ->select('country_code', DB::raw('COUNT(*) as count'))
+            ->groupBy('country_code')
+            ->orderByDesc('count')
+            ->get());
     }
 
     /**

--- a/resources/views/portal/livewire/statistic/index.blade.php
+++ b/resources/views/portal/livewire/statistic/index.blade.php
@@ -7,6 +7,7 @@
   @include('portal::livewire.statistic.partials.global-stats')
   @include('portal::livewire.statistic.partials.quality-health')
   @include('portal::livewire.statistic.partials.user-engagement')
+  @include('portal::livewire.statistic.partials.users-by-country')
   @include('portal::livewire.statistic.partials.country-stats')
   @include('portal::livewire.statistic.partials.top-lists')
   @include('portal::livewire.statistic.partials.recipes-per-month')

--- a/resources/views/portal/livewire/statistic/partials/users-by-country.blade.php
+++ b/resources/views/portal/livewire/statistic/partials/users-by-country.blade.php
@@ -1,0 +1,24 @@
+{{-- Users by Country --}}
+<flux:card>
+  <flux:heading size="lg">Users by Country</flux:heading>
+  <flux:table class="mt-section">
+    <flux:table.columns>
+      <flux:table.column class="ui-text-subtle">Country</flux:table.column>
+      <flux:table.column class="ui-text-subtle" align="end">Users</flux:table.column>
+    </flux:table.columns>
+    <flux:table.rows>
+      @foreach($this->usersByCountry as $countryStat)
+        <flux:table.row wire:key="user-country-{{ $countryStat->country_code ?? 'unknown' }}">
+          <flux:table.cell>
+            @if($countryStat->country_code)
+              {{ Str::countryFlag($countryStat->country_code) }} {{ __('country.' . $countryStat->country_code) }}
+            @else
+              🌐 Not set
+            @endif
+          </flux:table.cell>
+          <flux:table.cell align="end" class="tabular-nums">{{ number_format($countryStat->count) }}</flux:table.cell>
+        </flux:table.row>
+      @endforeach
+    </flux:table.rows>
+  </flux:table>
+</flux:card>


### PR DESCRIPTION
- Introduced `usersByCountry` computation in `Statistic` component.
- Added `users-by-country` partial view with table showing user counts grouped by country, including flags.
- Updated `StatisticsService` to fetch and cache users by country data.