### PR TITLE
refactor(jobs): split `ActivateCountryResourcesJob` into individual resource activation jobs

### DIFF
--- a/app/Jobs/Country/ActivateCountryResources/AbstractActivateResourceJob.php
+++ b/app/Jobs/Country/ActivateCountryResources/AbstractActivateResourceJob.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Jobs\Country\ActivateCountryResources;
+
+use App\Enums\QueueEnum;
+use App\Models\Country;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Context;
+
+/**
+ * Abstract base job for activating country resources based on recipe count.
+ */
+abstract class AbstractActivateResourceJob implements ShouldQueue
+{
+    use Batchable;
+    use Queueable;
+
+    public function __construct(
+        protected Country $country,
+    ) {
+        $this->onQueue(QueueEnum::Long->value);
+    }
+
+    public function handle(): void
+    {
+        if ($this->batch()?->cancelled()) {
+            return;
+        }
+
+        Context::add('country', $this->country->id);
+
+        $modelClass = $this->getModelClass();
+        $threshold = $this->getMinimumRecipeCount();
+
+        $modelClass::where('country_id', $this->country->getKey())
+            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
+            ->each(fn (Model $model) => $model->updateQuietly([
+                'active' => (int) $model->getAttribute('recipes_count') > $threshold,
+            ]));
+    }
+
+    /**
+     * Get the model class to process.
+     *
+     * @return class-string<Model>
+     */
+    abstract protected function getModelClass(): string;
+
+    /**
+     * Get the minimum recipe count threshold for activation.
+     */
+    protected function getMinimumRecipeCount(): int
+    {
+        return 3;
+    }
+}

--- a/app/Jobs/Country/ActivateCountryResources/ActivateAllergensJob.php
+++ b/app/Jobs/Country/ActivateCountryResources/ActivateAllergensJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Jobs\Country\ActivateCountryResources;
+
+use App\Models\Allergen;
+
+/**
+ * Activates allergens based on recipe count.
+ */
+class ActivateAllergensJob extends AbstractActivateResourceJob
+{
+    protected function getModelClass(): string
+    {
+        return Allergen::class;
+    }
+}

--- a/app/Jobs/Country/ActivateCountryResources/ActivateCuisinesJob.php
+++ b/app/Jobs/Country/ActivateCountryResources/ActivateCuisinesJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Jobs\Country\ActivateCountryResources;
+
+use App\Models\Cuisine;
+
+/**
+ * Activates cuisines based on recipe count.
+ */
+class ActivateCuisinesJob extends AbstractActivateResourceJob
+{
+    protected function getModelClass(): string
+    {
+        return Cuisine::class;
+    }
+}

--- a/app/Jobs/Country/ActivateCountryResources/ActivateIngredientsJob.php
+++ b/app/Jobs/Country/ActivateCountryResources/ActivateIngredientsJob.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Jobs\Country\ActivateCountryResources;
+
+use App\Models\Ingredient;
+use Override;
+
+/**
+ * Activates ingredients based on recipe count.
+ */
+class ActivateIngredientsJob extends AbstractActivateResourceJob
+{
+    protected function getModelClass(): string
+    {
+        return Ingredient::class;
+    }
+
+    #[Override]
+    protected function getMinimumRecipeCount(): int
+    {
+        return 0;
+    }
+}

--- a/app/Jobs/Country/ActivateCountryResources/ActivateLabelsJob.php
+++ b/app/Jobs/Country/ActivateCountryResources/ActivateLabelsJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Jobs\Country\ActivateCountryResources;
+
+use App\Models\Label;
+
+/**
+ * Activates labels based on recipe count.
+ */
+class ActivateLabelsJob extends AbstractActivateResourceJob
+{
+    protected function getModelClass(): string
+    {
+        return Label::class;
+    }
+}

--- a/app/Jobs/Country/ActivateCountryResources/ActivateTagsJob.php
+++ b/app/Jobs/Country/ActivateCountryResources/ActivateTagsJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Jobs\Country\ActivateCountryResources;
+
+use App\Models\Tag;
+
+/**
+ * Activates tags based on recipe count.
+ */
+class ActivateTagsJob extends AbstractActivateResourceJob
+{
+    protected function getModelClass(): string
+    {
+        return Tag::class;
+    }
+}

--- a/app/Jobs/Country/ActivateCountryResources/ActivateUtensilsJob.php
+++ b/app/Jobs/Country/ActivateCountryResources/ActivateUtensilsJob.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Jobs\Country\ActivateCountryResources;
+
+use App\Models\Utensil;
+
+/**
+ * Activates utensils based on recipe count.
+ */
+class ActivateUtensilsJob extends AbstractActivateResourceJob
+{
+    protected function getModelClass(): string
+    {
+        return Utensil::class;
+    }
+}

--- a/app/Jobs/Country/ActivateCountryResourcesJob.php
+++ b/app/Jobs/Country/ActivateCountryResourcesJob.php
@@ -3,19 +3,20 @@
 namespace App\Jobs\Country;
 
 use App\Enums\QueueEnum;
-use App\Models\Allergen;
+use App\Jobs\Country\ActivateCountryResources\ActivateAllergensJob;
+use App\Jobs\Country\ActivateCountryResources\ActivateCuisinesJob;
+use App\Jobs\Country\ActivateCountryResources\ActivateIngredientsJob;
+use App\Jobs\Country\ActivateCountryResources\ActivateLabelsJob;
+use App\Jobs\Country\ActivateCountryResources\ActivateTagsJob;
+use App\Jobs\Country\ActivateCountryResources\ActivateUtensilsJob;
 use App\Models\Country;
-use App\Models\Cuisine;
-use App\Models\Ingredient;
-use App\Models\Label;
-use App\Models\Tag;
-use App\Models\Utensil;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Bus;
+use Throwable;
 
 /**
- * Updates the active status for activatable models based on recipe count.
+ * Dispatches jobs to update the active status for activatable models based on recipe count.
  */
 class ActivateCountryResourcesJob implements ShouldQueue
 {
@@ -24,47 +25,24 @@ class ActivateCountryResourcesJob implements ShouldQueue
     public function __construct(
         protected Country $country,
     ) {
-        $this->onQueue(QueueEnum::Long->value);
+        $this->onQueue(QueueEnum::Default->value);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function handle(): void
     {
-        $countryId = $this->country->getKey();
-
-        // Update allergens - use withCount to get recipe counts efficiently
-        Allergen::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Allergen $allergen) => $allergen->updateQuietly(['active' => $allergen->recipes_count > 3]));
-
-        // Update cuisines
-        Cuisine::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Cuisine $cuisine) => $cuisine->updateQuietly(['active' => $cuisine->recipes_count > 3]));
-
-        // Update tags
-        Tag::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Tag $tag) => $tag->updateQuietly(['active' => $tag->recipes_count > 3]));
-
-        // Update utensils
-        Utensil::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Utensil $utensil) => $utensil->updateQuietly(['active' => $utensil->recipes_count > 3]));
-
-        // Update labels
-        Label::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Label $label) => $label->updateQuietly(['active' => $label->recipes_count > 3]));
-
-        // Update ingredients
-        Ingredient::where('country_id', $countryId)
-            ->withCount(['recipes' => fn (Builder $query) => $query->whereNull('recipes.deleted_at')])
-            ->get()
-            ->each(fn (Ingredient $ingredient) => $ingredient->updateQuietly(['active' => $ingredient->recipes_count > 0]));
+        Bus::batch([
+            new ActivateAllergensJob($this->country),
+            new ActivateCuisinesJob($this->country),
+            new ActivateTagsJob($this->country),
+            new ActivateUtensilsJob($this->country),
+            new ActivateLabelsJob($this->country),
+            new ActivateIngredientsJob($this->country),
+        ])
+            ->name('Activate Country Resources: ' . $this->country->code)
+            ->onQueue(QueueEnum::Long->value)
+            ->dispatch();
     }
 }

--- a/resources/views/flux/icon/boxes.blade.php
+++ b/resources/views/flux/icon/boxes.blade.php
@@ -1,0 +1,54 @@
+@blaze
+
+{{-- Credit: Lucide (https://lucide.dev) --}}
+
+@props([
+    'variant' => 'outline',
+])
+
+@php
+if ($variant === 'solid') {
+    throw new \Exception('The "solid" variant is not supported in Lucide.');
+}
+
+$classes = Flux::classes('shrink-0')
+    ->add(match($variant) {
+        'outline' => '[:where(&)]:size-6',
+        'solid' => '[:where(&)]:size-6',
+        'mini' => '[:where(&)]:size-5',
+        'micro' => '[:where(&)]:size-4',
+    });
+
+$strokeWidth = match ($variant) {
+    'outline' => 2,
+    'mini' => 2.25,
+    'micro' => 2.5,
+};
+@endphp
+
+<svg
+    {{ $attributes->class($classes) }}
+    data-flux-icon
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="{{ $strokeWidth }}"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+    data-slot="icon"
+>
+  <path d="M2.97 12.92A2 2 0 0 0 2 14.63v3.24a2 2 0 0 0 .97 1.71l3 1.8a2 2 0 0 0 2.06 0L12 19v-5.5l-5-3-4.03 2.42Z" />
+  <path d="m7 16.5-4.74-2.85" />
+  <path d="m7 16.5 5-3" />
+  <path d="M7 16.5v5.17" />
+  <path d="M12 13.5V19l3.97 2.38a2 2 0 0 0 2.06 0l3-1.8a2 2 0 0 0 .97-1.71v-3.24a2 2 0 0 0-.97-1.71L17 10.5l-5 3Z" />
+  <path d="m17 16.5-5-3" />
+  <path d="m17 16.5 4.74-2.85" />
+  <path d="M17 16.5v5.17" />
+  <path d="M7.97 4.42A2 2 0 0 0 7 6.13v4.37l5 3 5-3V6.13a2 2 0 0 0-.97-1.71l-3-1.8a2 2 0 0 0-2.06 0l-3 1.8Z" />
+  <path d="M12 8 7.26 5.15" />
+  <path d="m12 8 4.74-2.85" />
+  <path d="M12 13.5V8" />
+</svg>

--- a/resources/views/web/components/layouts/localized/footer.blade.php
+++ b/resources/views/web/components/layouts/localized/footer.blade.php
@@ -10,8 +10,8 @@
         <span>GitHub</span>
       </flux:link>
       <flux:link :href="route('portal.dashboard')" class="inline-flex items-center gap-1 hover:text-zinc-700 dark:hover:text-zinc-200">
-        <flux:icon.code variant="micro" />
-        <span>API</span>
+        <flux:icon.boxes variant="micro" />
+        <span>API + Data Portal</span>
       </flux:link>
     </div>
     <div>


### PR DESCRIPTION
- Introduced `AbstractActivateResourceJob` to handle shared activation logic.
- Created separate jobs for allergens, cuisines, ingredients, labels, tags, and utensils.
- Updated `ActivateCountryResourcesJob` to dispatch these as a batch for better modularization and clarity.