### PR TITLE
docs(readme): update API portal description for clarity and remove redundant Reddit text in links section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Unofficial HelloFresh recipe database for 16 countries with features like filter
 ## Links
 
 * [hfresh.info](https://hfresh.info) - Live website
-* [API Portal](https://console.hfresh.info) - For API and statistics
-* [Reddit Post](https://www.reddit.com/r/hellofresh/comments/1b37z4x/hellofresh_recipes_database_relaunched/) - Active community
+* [API Portal](https://console.hfresh.info) - API + Data Portal: For API, statistics and power users
+* [Reddit Post](https://www.reddit.com/r/hellofresh/comments/1b37z4x/hellofresh_recipes_database_relaunched/)
 * [Ko-Fi](https://ko-fi.com/post/HelloFresh-Recipes-Database-Relaunched-D1D8V2OF7)
 * [LinkedIn](https://www.linkedin.com/posts/normanhuth_hellofresh-database-activity-7169039554446901248-CrKH)
 

--- a/resources/views/portal/livewire/dashboard.blade.php
+++ b/resources/views/portal/livewire/dashboard.blade.php
@@ -1,5 +1,5 @@
 <div class="space-y-section">
-  <flux:heading size="xl">{{ config('app.name') }} API</flux:heading>
+  <flux:heading size="xl">{{ config('app.name') }}</flux:heading>
   <flux:text>Access recipe data, menus, ingredients, and more through our REST API.</flux:text>
 
   <img


### PR DESCRIPTION
- Simplified dashboard heading by removing "API" suffix.