### PR TITLE
fix(api): update filtering logic to use tag and label IDs instead of slugs

### DIFF
--- a/app/Http/Controllers/Api/Localized/RecipeController.php
+++ b/app/Http/Controllers/Api/Localized/RecipeController.php
@@ -32,12 +32,12 @@ class RecipeController extends AbstractLocalizedController
                 })
                 ->when($request->filled('tag'), function (Builder $query) use ($request): void {
                     $query->whereHas('tags', function (Builder $query) use ($request): void {
-                        $query->where('slug', $request->input('tag'));
+                        $query->where('id', $request->input('tag'));
                     });
                 })
                 ->when($request->filled('label'), function (Builder $query) use ($request): void {
                     $query->whereHas('label', function (Builder $query) use ($request): void {
-                        $query->where('slug', $request->input('label'));
+                        $query->where('id', $request->input('label'));
                     });
                 })
                 ->when($request->filled('difficulty'), function (Builder $query) use ($request): void {

--- a/app/Livewire/Portal/Docs/RecipesIndexDoc.php
+++ b/app/Livewire/Portal/Docs/RecipesIndexDoc.php
@@ -31,8 +31,8 @@ class RecipesIndexDoc extends AbstractEndpointDoc
     {
         return [
             ['name' => 'search', 'type' => 'string', 'description' => 'Filter recipes by name (case-insensitive)'],
-            ['name' => 'tag', 'type' => 'string', 'description' => 'Filter by tag slug'],
-            ['name' => 'label', 'type' => 'string', 'description' => 'Filter by label slug'],
+            ['name' => 'tag', 'type' => 'integer', 'description' => 'Filter by tag ID'],
+            ['name' => 'label', 'type' => 'integer', 'description' => 'Filter by label ID'],
             ['name' => 'difficulty', 'type' => 'integer', 'description' => 'Filter by difficulty level (1-3)'],
             ['name' => 'has_pdf', 'type' => 'boolean', 'description' => 'Filter recipes that have a PDF card'],
             ['name' => 'per_page', 'type' => 'integer', 'description' => 'Results per page (' . config('api.pagination.per_page_min') . '-' . config('api.pagination.per_page_max') . ', default ' . config('api.pagination.per_page_default') . ')'],


### PR DESCRIPTION
- Updated `RecipesIndexDoc` to reflect the change from slugs to IDs for `tag` and `label`.
- Modified `RecipeController` to filter by `id` instead of `slug` for tags and labels.