### PR TITLE
refactor(flags): replace custom country flag logic with `flag-icons` library

### DIFF
--- a/app/Livewire/Web/RegionSelect.php
+++ b/app/Livewire/Web/RegionSelect.php
@@ -13,19 +13,6 @@ use Livewire\Attributes\Layout;
 class RegionSelect extends AbstractComponent
 {
     /**
-     * Convert a country code to a flag emoji.
-     */
-    public function getFlagEmoji(string $countryCode): string
-    {
-        $codePoints = array_map(
-            static fn (string $char): string => mb_chr(ord($char) - ord('A') + 0x1F1E6),
-            str_split(strtoupper($countryCode))
-        );
-
-        return implode('', $codePoints);
-    }
-
-    /**
      * Get all active countries.
      *
      * @return Collection<int, Country>

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,7 +12,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
 
 /**
@@ -135,18 +134,6 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(RecipeList::class, 'recipe_list_shares')
             ->withPivot('created_at');
-    }
-
-    /**
-     * Get the user's country flag emoji.
-     */
-    public function countryFlag(): ?string
-    {
-        if ($this->country_code === null) {
-            return null;
-        }
-
-        return Str::countryFlag($this->country_code);
     }
 
     /**

--- a/app/Providers/MacroServiceProvider.php
+++ b/app/Providers/MacroServiceProvider.php
@@ -31,18 +31,5 @@ class MacroServiceProvider extends ServiceProvider
             'normalizeNameStrict',
             fn (string $value): string => Str::ucfirst(Str::squish(rtrim(Str::before($value, ' ('), '*')))
         );
-
-        Str::macro(
-            'countryFlag',
-            function (string $countryCode): string {
-                $code = Str::upper($countryCode);
-                $flag = '';
-                for ($i = 0; $i < strlen($code); $i++) {
-                    $flag .= mb_chr(ord($code[$i]) - ord('A') + 0x1F1E6);
-                }
-
-                return $flag;
-            }
-        );
     }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "@tailwindcss/vite": "^4.1.17",
         "axios": "^1.13.2",
         "concurrently": "^9.2.1",
+        "flag-icons": "^7.5.0",
         "laravel-echo": "^2.2.6",
         "laravel-vite-plugin": "^2.0.1",
         "pusher-js": "^8.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
+      flag-icons:
+        specifier: ^7.5.0
+        version: 7.5.0
       laravel-echo:
         specifier: ^2.2.6
         version: 2.2.6(pusher-js@8.4.0)(socket.io-client@4.8.1)
@@ -523,6 +526,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  flag-icons@7.5.0:
+    resolution: {integrity: sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -1228,6 +1234,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  flag-icons@7.5.0: {}
 
   follow-redirects@1.15.11: {}
 

--- a/resources/css/common.css
+++ b/resources/css/common.css
@@ -1,3 +1,6 @@
+/* Flag Icons */
+@import 'flag-icons/css/flag-icons.css';
+
 @theme {
   --font-sans: Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --font-mono: JetBrains Mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;

--- a/resources/views/components/country-select.blade.php
+++ b/resources/views/components/country-select.blade.php
@@ -1,21 +1,22 @@
 @php
-    use Illuminate\Support\Str;
-
-    $countries = __('country');
-    asort($countries);
+  $countries = __('country');
+  asort($countries);
 @endphp
 
 <flux:select
-    variant="listbox"
-    searchable
-    clearable
-    :label="__('Country')"
-    :placeholder="__('Select your country (optional)')"
-    {{ $attributes }}
+  variant="listbox"
+  searchable
+  clearable
+  :label="__('Country')"
+  :placeholder="__('Select your country (optional)')"
+  {{ $attributes }}
 >
-    @foreach ($countries as $code => $countryName)
-        <flux:select.option :value="$code">
-            {{ Str::countryFlag($code) }} {{ $countryName }}
-        </flux:select.option>
-    @endforeach
+  @foreach ($countries as $code => $countryName)
+    <flux:select.option :value="$code">
+      <div class="flex items-center gap-2">
+        <x-flag :code="$code" class="inline-block align-middle"/> {{ $countryName }}
+      </div>
+
+    </flux:select.option>
+  @endforeach
 </flux:select>

--- a/resources/views/components/flag.blade.php
+++ b/resources/views/components/flag.blade.php
@@ -1,0 +1,6 @@
+@props([
+    'code',
+    'squared' => false,
+])
+
+<span {{ $attributes->class(['fi', 'fi-' . strtolower($code), 'fis' => $squared]) }}></span>

--- a/resources/views/portal/livewire/admin/user-index.blade.php
+++ b/resources/views/portal/livewire/admin/user-index.blade.php
@@ -92,7 +92,7 @@
             </flux:table.cell>
             <flux:table.cell>
               @if($user->country_code)
-                <span title="{{ $user->countryName() }}">{{ $user->countryFlag() }} {{ $user->country_code }}</span>
+                <span title="{{ $user->countryName() }}"><x-flag :code="$user->country_code" /> {{ $user->country_code }}</span>
               @else
                 <flux:text variant="subtle">—</flux:text>
               @endif

--- a/resources/views/portal/livewire/recipe-lists/show.blade.php
+++ b/resources/views/portal/livewire/recipe-lists/show.blade.php
@@ -25,7 +25,7 @@
             <div class="space-y-ui">
                 <div class="flex items-center gap-ui">
                     @if ($group['country'])
-                        <flux:heading size="lg">{{ Str::countryFlag($group['country']->code) }} {{ __('country.' . $group['country']->code) }}</flux:heading>
+                        <flux:heading size="lg"><x-flag :code="$group['country']->code" /> {{ __('country.' . $group['country']->code) }}</flux:heading>
                     @else
                         <flux:heading size="lg">{{ __('Unknown Country') }}</flux:heading>
                     @endif

--- a/resources/views/portal/livewire/stats/recipe-stats.blade.php
+++ b/resources/views/portal/livewire/stats/recipe-stats.blade.php
@@ -169,7 +169,7 @@
         @foreach($this->countryStats as $country)
           <flux:table.row wire:key="country-{{ $country->id }}">
             <flux:table.cell>
-              <span class="font-medium">{{ Str::countryFlag($country->code) }} {{ $country->code }}</span>
+              <span class="font-medium"><x-flag :code="$country->code" /> {{ $country->code }}</span>
             </flux:table.cell>
             <flux:table.cell>{{ __('country.' . $country->code) }}</flux:table.cell>
             <flux:table.cell>
@@ -210,7 +210,7 @@
           @foreach($this->topIngredients as $ingredient)
             <flux:table.row wire:key="ingredient-{{ $loop->index }}">
               <flux:table.cell class="truncate max-w-48">
-                <span title="{{ $ingredient->country_code }}">{{ Str::countryFlag($ingredient->country_code) }}</span>
+                <x-flag :code="$ingredient->country_code" :title="$ingredient->country_code" />
                 {{ json_decode($ingredient->name)->en ?? $ingredient->name }}
               </flux:table.cell>
               <flux:table.cell align="end" class="tabular-nums">{{ number_format($ingredient->recipes_count) }}</flux:table.cell>
@@ -231,7 +231,7 @@
           @foreach($this->topTags as $tag)
             <flux:table.row wire:key="tag-{{ $loop->index }}">
               <flux:table.cell class="truncate max-w-48">
-                <span title="{{ $tag->country_code }}">{{ Str::countryFlag($tag->country_code) }}</span>
+                <x-flag :code="$tag->country_code" :title="$tag->country_code" />
                 {{ json_decode($tag->name)->en ?? $tag->name }}
               </flux:table.cell>
               <flux:table.cell align="end" class="tabular-nums">{{ number_format($tag->recipes_count) }}</flux:table.cell>
@@ -252,7 +252,7 @@
           @foreach($this->topCuisines as $cuisine)
             <flux:table.row wire:key="cuisine-{{ $loop->index }}">
               <flux:table.cell class="truncate max-w-48">
-                <span title="{{ $cuisine->country_code }}">{{ Str::countryFlag($cuisine->country_code) }}</span>
+                <x-flag :code="$cuisine->country_code" :title="$cuisine->country_code" />
                 {{ json_decode($cuisine->name)->en ?? $cuisine->name }}
               </flux:table.cell>
               <flux:table.cell align="end" class="tabular-nums">{{ number_format($cuisine->recipes_count) }}</flux:table.cell>
@@ -311,7 +311,7 @@
         @foreach($this->avgPrepTimesByCountry as $country)
           <flux:table.row wire:key="prep-{{ $country->code }}">
             <flux:table.cell>
-              <span class="font-medium">{{ Str::countryFlag($country->code) }} {{ $country->code }}</span>
+              <span class="font-medium"><x-flag :code="$country->code" /> {{ $country->code }}</span>
             </flux:table.cell>
             <flux:table.cell align="end" class="tabular-nums">{{ $country->avg_prep }} min</flux:table.cell>
             <flux:table.cell align="end" class="tabular-nums">{{ $country->avg_total }} min</flux:table.cell>

--- a/resources/views/portal/livewire/stats/user-stats.blade.php
+++ b/resources/views/portal/livewire/stats/user-stats.blade.php
@@ -74,7 +74,7 @@
           <flux:table.row wire:key="user-country-{{ $countryStat->country_code ?? 'unknown' }}">
             <flux:table.cell>
               @if($countryStat->country_code)
-                {{ Str::countryFlag($countryStat->country_code) }} {{ __('country.' . $countryStat->country_code) }}
+                <x-flag :code="$countryStat->country_code" /> {{ __('country.' . $countryStat->country_code) }}
               @else
                 <span class="text-zinc-400">Not set</span>
               @endif

--- a/resources/views/web/livewire/region-select.blade.php
+++ b/resources/views/web/livewire/region-select.blade.php
@@ -8,7 +8,7 @@
     @foreach ($this->countries as $country)
       <flux:card wire:key="country-{{ $country->id }}" size="sm">
         <div class="flex items-center justify-center gap-ui mb-ui">
-          <span class="text-2xl">{{ $this->getFlagEmoji($country->code) }}</span>
+          <x-flag :code="$country->code" class="text-2xl" />
           <flux:heading size="lg">
             {{ __('country.' . $country->code) }}
           </flux:heading>

--- a/resources/views/web/livewire/user/user-recipe-lists.blade.php
+++ b/resources/views/web/livewire/user/user-recipe-lists.blade.php
@@ -68,7 +68,7 @@
                           {{ $activity->recipe->name }}
                         </flux:link>
                       @else
-                        <strong>{{ Str::countryFlag($activity->recipe->country->code) }} {{ $activity->recipe?->getFirstTranslation('name') }}</strong>
+                        <strong><x-flag :code="$activity->recipe->country->code" /> {{ $activity->recipe?->getFirstTranslation('name') }}</strong>
                       @endif
                       <span class="text-zinc-400">{{ $activity->created_at->diffForHumans() }}</span>
                     </flux:text>

--- a/tests/Unit/Livewire/RegionSelectTest.php
+++ b/tests/Unit/Livewire/RegionSelectTest.php
@@ -23,32 +23,6 @@ final class RegionSelectTest extends TestCase
     }
 
     #[Test]
-    public function it_converts_country_code_to_flag_emoji(): void
-    {
-        $component = Livewire::test(RegionSelect::class);
-
-        $usFlag = $component->instance()->getFlagEmoji('US');
-        $deFlag = $component->instance()->getFlagEmoji('DE');
-        $frFlag = $component->instance()->getFlagEmoji('FR');
-
-        $this->assertNotEmpty($usFlag);
-        $this->assertNotEmpty($deFlag);
-        $this->assertNotEmpty($frFlag);
-        $this->assertNotSame($usFlag, $deFlag);
-    }
-
-    #[Test]
-    public function it_handles_lowercase_country_code(): void
-    {
-        $component = Livewire::test(RegionSelect::class);
-
-        $upperFlag = $component->instance()->getFlagEmoji('US');
-        $lowerFlag = $component->instance()->getFlagEmoji('us');
-
-        $this->assertSame($upperFlag, $lowerFlag);
-    }
-
-    #[Test]
     public function it_returns_only_active_countries(): void
     {
         Country::factory()->create(['code' => 'US', 'active' => true, 'prep_min' => 5, 'recipes_count' => 100, 'ingredients_count' => 50]);


### PR DESCRIPTION
- Migrate all instances of `Str::countryFlag` to the new reusable `<x-flag>` component.
- Remove deprecated `countryFlag` Str macro and related test cases.
- Import `flag-icons` library and add it to `package.json` dependencies.
- Add `resources/views/components/flag.blade.php` for centralized flag rendering.
- Update existing views and tests to use `<x-flag>` for cleaner, consistent implementation.