### PR TITLE
chore(portal): refine email verification handling and update view structures

### DIFF
--- a/app/Livewire/Portal/Tokens/TokenIndex.php
+++ b/app/Livewire/Portal/Tokens/TokenIndex.php
@@ -37,16 +37,16 @@ class TokenIndex extends AbstractComponent
      */
     public function createToken(): void
     {
+        $user = auth()->user();
+
+        if (! $user || ! $user->hasVerifiedEmail()) {
+            return;
+        }
+
         $this->validate([
             'tokenName' => ['required', 'string', 'min:3', 'max:255'],
             'tokenExpiration' => ['required', 'integer', 'in:7,30,90,180'],
         ]);
-
-        $user = auth()->user();
-
-        if (! $user) {
-            return;
-        }
 
         $expiresAt = now()->addDays($this->tokenExpiration);
         $token = $user->createToken($this->tokenName, ['*'], $expiresAt);

--- a/resources/views/portal/components/layouts/guest.blade.php
+++ b/resources/views/portal/components/layouts/guest.blade.php
@@ -29,7 +29,7 @@
   @fluxAppearance
 </head>
 <body class="min-h-screen bg-zinc-50 dark:bg-zinc-900 antialiased">
-<div class="min-h-screen flex flex-col items-center justify-center p-section">
+<flux:main class="min-h-screen flex flex-col items-center justify-center p-section">
   <flux:heading class="mb-4 inline-flex gap-1 items-center text-xl">
     <flux:icon.earth />
     {{ config('app.name') }} API
@@ -38,7 +38,7 @@
   <flux:card class="w-full max-w-md">
     {{ $slot }}
   </flux:card>
-</div>
+</flux:main>
 
 <flux:toast.group position="bottom end">
   <flux:toast />

--- a/resources/views/portal/livewire/auth/login.blade.php
+++ b/resources/views/portal/livewire/auth/login.blade.php
@@ -1,4 +1,4 @@
-<flux:main container class="space-y-section">
+<div class="space-y-section">
     <div class="text-center">
         <flux:heading size="lg">Sign in to your account</flux:heading>
         <flux:text class="mt-ui">
@@ -30,4 +30,4 @@
             Sign in
         </flux:button>
     </form>
-</flux:main>
+</div>

--- a/resources/views/portal/livewire/auth/register.blade.php
+++ b/resources/views/portal/livewire/auth/register.blade.php
@@ -1,4 +1,4 @@
-<flux:main container class="space-y-section">
+<div class="space-y-section">
     <div class="text-center">
         <flux:heading size="lg">Create your account</flux:heading>
         <flux:text class="mt-ui">
@@ -59,4 +59,4 @@
             Create account
         </flux:button>
     </form>
-</flux:main>
+</div>

--- a/resources/views/portal/livewire/auth/verify-email.blade.php
+++ b/resources/views/portal/livewire/auth/verify-email.blade.php
@@ -1,4 +1,4 @@
-<flux:main container class="space-y-section">
+<div class="space-y-section">
     <div class="text-center">
         <flux:heading size="lg">Verify your email</flux:heading>
         <flux:text class="mt-ui">
@@ -7,10 +7,8 @@
         </flux:text>
     </div>
 
-    <flux:callout icon="information-circle" color="blue">
-        <flux:callout.text>
-            If you didn't receive the email, check your spam folder or click the button below to resend.
-        </flux:callout.text>
+    <flux:callout icon="info" color="blue">
+        If you didn't receive the email, check your spam folder or click the button below to resend.
     </flux:callout>
 
     <flux:button wire:click="resend" variant="primary" class="w-full">
@@ -22,4 +20,4 @@
             Skip for now
         </flux:link>
     </div>
-</flux:main>
+</div>

--- a/resources/views/portal/livewire/resources/resource-index.blade.php
+++ b/resources/views/portal/livewire/resources/resource-index.blade.php
@@ -1,5 +1,4 @@
 <flux:main container class="space-y-section">
-  <x-portal::email-not-verified />
   <flux:breadcrumbs>
     <flux:breadcrumbs.item :href="route('portal.dashboard')" wire:navigate>Home</flux:breadcrumbs.item>
     <flux:breadcrumbs.item :href="route('portal.resources.index')" wire:navigate>Resources</flux:breadcrumbs.item>

--- a/resources/views/portal/livewire/stats/api-stats.blade.php
+++ b/resources/views/portal/livewire/stats/api-stats.blade.php
@@ -1,5 +1,4 @@
 <flux:main container class="space-y-section">
-    <x-portal::email-not-verified />
   <flux:breadcrumbs>
     <flux:breadcrumbs.item :href="route('portal.dashboard')" wire:navigate>Home</flux:breadcrumbs.item>
     <flux:breadcrumbs.item :href="route('portal.stats.index')" wire:navigate>Statistics</flux:breadcrumbs.item>

--- a/resources/views/portal/livewire/stats/index.blade.php
+++ b/resources/views/portal/livewire/stats/index.blade.php
@@ -1,5 +1,4 @@
 <flux:main container class="space-y-section">
-    <x-portal::email-not-verified />
   <flux:breadcrumbs>
     <flux:breadcrumbs.item :href="route('portal.dashboard')" wire:navigate>Home</flux:breadcrumbs.item>
     <flux:breadcrumbs.item>Statistics</flux:breadcrumbs.item>

--- a/resources/views/portal/livewire/stats/recipe-stats.blade.php
+++ b/resources/views/portal/livewire/stats/recipe-stats.blade.php
@@ -1,5 +1,4 @@
 <flux:main container class="space-y-section">
-    <x-portal::email-not-verified />
   <flux:breadcrumbs>
     <flux:breadcrumbs.item :href="route('portal.dashboard')" wire:navigate>Home</flux:breadcrumbs.item>
     <flux:breadcrumbs.item :href="route('portal.stats.index')" wire:navigate>Statistics</flux:breadcrumbs.item>

--- a/resources/views/portal/livewire/stats/user-stats.blade.php
+++ b/resources/views/portal/livewire/stats/user-stats.blade.php
@@ -1,5 +1,4 @@
 <flux:main container class="space-y-section">
-    <x-portal::email-not-verified />
   <flux:breadcrumbs>
     <flux:breadcrumbs.item :href="route('portal.dashboard')" wire:navigate>Home</flux:breadcrumbs.item>
     <flux:breadcrumbs.item :href="route('portal.stats.index')" wire:navigate>Statistics</flux:breadcrumbs.item>

--- a/resources/views/portal/livewire/tokens/index.blade.php
+++ b/resources/views/portal/livewire/tokens/index.blade.php
@@ -1,9 +1,18 @@
 <flux:main container class="space-y-section">
-    <x-portal::email-not-verified />
+    @if(! auth()->user()->hasVerifiedEmail())
+        <flux:callout icon="triangle-alert" color="amber">
+            <flux:callout.heading>Email Verification Required</flux:callout.heading>
+            <flux:callout.text>
+                You must verify your email address before creating API tokens.
+                <flux:link :href="route('portal.verification.notice')" wire:navigate>Verify now</flux:link>
+            </flux:callout.text>
+        </flux:callout>
+    @endif
+
     <div class="flex items-center justify-between">
         <flux:heading size="xl">API Tokens</flux:heading>
-        <flux:modal.trigger name="create-token">
-            <flux:button variant="primary" icon="plus">
+        <flux:modal.trigger name="create-token" :disabled="! auth()->user()->hasVerifiedEmail()">
+            <flux:button variant="primary" icon="plus" :disabled="! auth()->user()->hasVerifiedEmail()">
                 Create Token
             </flux:button>
         </flux:modal.trigger>
@@ -33,8 +42,8 @@
                     Create your first API token to start making authenticated requests.
                 </flux:text>
                 <div class="mt-section">
-                    <flux:modal.trigger name="create-token">
-                        <flux:button variant="primary" icon="plus">
+                    <flux:modal.trigger name="create-token" :disabled="! auth()->user()->hasVerifiedEmail()">
+                        <flux:button variant="primary" icon="plus" :disabled="! auth()->user()->hasVerifiedEmail()">
                             Create Token
                         </flux:button>
                     </flux:modal.trigger>


### PR DESCRIPTION
- Replace `<x-portal::email-not-verified />` component with conditional callouts for email verification in views
- Prevent unverified users from creating API tokens with visual and functional restrictions
- Transition `flux:main` element to `<div>` in select authentication views for consistency
- Update `TokenIndex` logic to enforce email verification checks when creating API tokens