### PR TITLE
chore(stats): replace raw DB queries with Eloquent relationships in top stats methods

### DIFF
--- a/app/Livewire/Portal/Stats/RecipeStats.php
+++ b/app/Livewire/Portal/Stats/RecipeStats.php
@@ -4,7 +4,10 @@ namespace App\Livewire\Portal\Stats;
 
 use App\Livewire\AbstractComponent;
 use App\Models\Country;
+use App\Models\Cuisine;
+use App\Models\Ingredient;
 use App\Models\Recipe;
+use App\Models\Tag;
 use App\Services\Portal\StatisticsService;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
@@ -101,7 +104,7 @@ class RecipeStats extends AbstractComponent
     /**
      * Get top ingredients by recipe count.
      *
-     * @return Collection<int, stdClass>
+     * @return Collection<int, Ingredient>
      */
     #[Computed]
     public function topIngredients(): Collection
@@ -112,7 +115,7 @@ class RecipeStats extends AbstractComponent
     /**
      * Get top tags by recipe count.
      *
-     * @return Collection<int, stdClass>
+     * @return Collection<int, Tag>
      */
     #[Computed]
     public function topTags(): Collection
@@ -123,7 +126,7 @@ class RecipeStats extends AbstractComponent
     /**
      * Get top cuisines by recipe count.
      *
-     * @return Collection<int, stdClass>
+     * @return Collection<int, Cuisine>
      */
     #[Computed]
     public function topCuisines(): Collection

--- a/app/Services/Portal/StatisticsService.php
+++ b/app/Services/Portal/StatisticsService.php
@@ -168,16 +168,13 @@ class StatisticsService
     /**
      * Get top ingredients by recipe count.
      *
-     * @return Collection<int, stdClass>
+     * @return Collection<int, Ingredient>
      */
     public function topIngredients(): Collection
     {
-        /** @var Collection<int, stdClass> */
-        return Cache::remember('portal_top_ingredients', $this->cacheTtl, static fn (): Collection => DB::table('ingredients')
-            ->join('ingredient_recipe', 'ingredients.id', '=', 'ingredient_recipe.ingredient_id')
-            ->join('countries', 'ingredients.country_id', '=', 'countries.id')
-            ->select('ingredients.name', 'countries.code as country_code', 'countries.locales as country_locales', DB::raw('COUNT(ingredient_recipe.recipe_id) as recipes_count'))
-            ->groupBy('ingredients.id', 'ingredients.name', 'countries.code', 'countries.locales')
+        /** @var Collection<int, Ingredient> */
+        return Cache::remember('portal_top_ingredients', $this->cacheTtl, static fn (): Collection => Ingredient::withCount('recipes')
+            ->with('country:id,code')
             ->orderByDesc('recipes_count')
             ->limit(10)
             ->get());
@@ -186,16 +183,13 @@ class StatisticsService
     /**
      * Get top tags by recipe count.
      *
-     * @return Collection<int, stdClass>
+     * @return Collection<int, Tag>
      */
     public function topTags(): Collection
     {
-        /** @var Collection<int, stdClass> */
-        return Cache::remember('portal_top_tags', $this->cacheTtl, static fn (): Collection => DB::table('tags')
-            ->join('recipe_tag', 'tags.id', '=', 'recipe_tag.tag_id')
-            ->join('countries', 'tags.country_id', '=', 'countries.id')
-            ->select('tags.name', 'countries.code as country_code', 'countries.locales as country_locales', DB::raw('COUNT(recipe_tag.recipe_id) as recipes_count'))
-            ->groupBy('tags.id', 'tags.name', 'countries.code', 'countries.locales')
+        /** @var Collection<int, Tag> */
+        return Cache::remember('portal_top_tags', $this->cacheTtl, static fn (): Collection => Tag::withCount('recipes')
+            ->with('country:id,code')
             ->orderByDesc('recipes_count')
             ->limit(10)
             ->get());
@@ -204,16 +198,13 @@ class StatisticsService
     /**
      * Get top cuisines by recipe count.
      *
-     * @return Collection<int, stdClass>
+     * @return Collection<int, Cuisine>
      */
     public function topCuisines(): Collection
     {
-        /** @var Collection<int, stdClass> */
-        return Cache::remember('portal_top_cuisines', $this->cacheTtl, static fn (): Collection => DB::table('cuisines')
-            ->join('cuisine_recipe', 'cuisines.id', '=', 'cuisine_recipe.cuisine_id')
-            ->join('countries', 'cuisines.country_id', '=', 'countries.id')
-            ->select('cuisines.name', 'countries.code as country_code', 'countries.locales as country_locales', DB::raw('COUNT(cuisine_recipe.recipe_id) as recipes_count'))
-            ->groupBy('cuisines.id', 'cuisines.name', 'countries.code', 'countries.locales')
+        /** @var Collection<int, Cuisine> */
+        return Cache::remember('portal_top_cuisines', $this->cacheTtl, static fn (): Collection => Cuisine::withCount('recipes')
+            ->with('country:id,code')
             ->orderByDesc('recipes_count')
             ->limit(10)
             ->get());

--- a/resources/views/portal/livewire/stats/recipe-stats.blade.php
+++ b/resources/views/portal/livewire/stats/recipe-stats.blade.php
@@ -210,7 +210,7 @@
           @foreach($this->topIngredients as $ingredient)
             <flux:table.row wire:key="ingredient-{{ $loop->index }}">
               <flux:table.cell class="truncate max-w-48">
-                <x-flag :code="$ingredient->country_code" :title="$ingredient->country_code" />
+                <x-flag :code="$ingredient->country->code" :title="$ingredient->country->code" />
                 {{ $ingredient->name }}
               </flux:table.cell>
               <flux:table.cell align="end" class="tabular-nums">{{ Number::format($ingredient->recipes_count) }}</flux:table.cell>
@@ -231,7 +231,7 @@
           @foreach($this->topTags as $tag)
             <flux:table.row wire:key="tag-{{ $loop->index }}">
               <flux:table.cell class="truncate max-w-48">
-                <x-flag :code="$tag->country_code" :title="$tag->country_code" />
+                <x-flag :code="$tag->country->code" :title="$tag->country->code" />
                 {{ $tag->name }}
               </flux:table.cell>
               <flux:table.cell align="end" class="tabular-nums">{{ Number::format($tag->recipes_count) }}</flux:table.cell>
@@ -252,7 +252,7 @@
           @foreach($this->topCuisines as $cuisine)
             <flux:table.row wire:key="cuisine-{{ $loop->index }}">
               <flux:table.cell class="truncate max-w-48">
-                <x-flag :code="$cuisine->country_code" :title="$cuisine->country_code" />
+                <x-flag :code="$cuisine->country->code" :title="$cuisine->country->code" />
                 {{ $cuisine->name }}
               </flux:table.cell>
               <flux:table.cell align="end" class="tabular-nums">{{ Number::format($cuisine->recipes_count) }}</flux:table.cell>


### PR DESCRIPTION


- Refactor `StatisticsService` to use Eloquent models (`Ingredient`, `Tag`, `Cuisine`) with `withCount` and `with` for `recipes` and `country` relationships
- Update `RecipeStats` component and views to reflect Eloquent model changes
- Simplify country flag references in `recipe-stats` view with direct model properties