### PR TITLE
fix(components): add localized layout attribute to Livewire components

### DIFF
--- a/app/Livewire/Web/Auth/AccountSetting.php
+++ b/app/Livewire/Web/Auth/AccountSetting.php
@@ -12,11 +12,13 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Layout;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileIsTooBig;
 
+#[Layout('web::components.layouts.localized')]
 class AccountSetting extends AbstractComponent
 {
     use WithFileUploads;

--- a/app/Livewire/Web/Legal/PrivacyPolicyShow.php
+++ b/app/Livewire/Web/Legal/PrivacyPolicyShow.php
@@ -7,7 +7,9 @@ use App\Livewire\Concerns\RendersMarkdownDocumentTrait;
 use App\Livewire\Web\Concerns\WithLocalizedContextTrait;
 use Illuminate\Contracts\View\View as ViewInterface;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
 
+#[Layout('web::components.layouts.localized')]
 class PrivacyPolicyShow extends AbstractComponent
 {
     use RendersMarkdownDocumentTrait;

--- a/app/Livewire/Web/Legal/TermsOfUseShow.php
+++ b/app/Livewire/Web/Legal/TermsOfUseShow.php
@@ -7,7 +7,9 @@ use App\Livewire\Concerns\RendersMarkdownDocumentTrait;
 use App\Livewire\Web\Concerns\WithLocalizedContextTrait;
 use Illuminate\Contracts\View\View as ViewInterface;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
 
+#[Layout('web::components.layouts.localized')]
 class TermsOfUseShow extends AbstractComponent
 {
     use RendersMarkdownDocumentTrait;

--- a/app/Livewire/Web/User/UserRecipeLists.php
+++ b/app/Livewire/Web/User/UserRecipeLists.php
@@ -14,7 +14,9 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
 
+#[Layout('web::components.layouts.localized')]
 class UserRecipeLists extends AbstractComponent
 {
     use WithLocalizedContextTrait;

--- a/app/Livewire/Web/User/UserShoppingLists.php
+++ b/app/Livewire/Web/User/UserShoppingLists.php
@@ -9,7 +9,9 @@ use App\Support\Facades\Flux;
 use Illuminate\Contracts\View\View as ViewInterface;
 use Illuminate\Support\Collection;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
 
+#[Layout('web::components.layouts.localized')]
 class UserShoppingLists extends AbstractComponent
 {
     use WithLocalizedContextTrait;


### PR DESCRIPTION
- Apply `#[Layout('web::components.layouts.localized')]` to standardize layout across `UserRecipeLists`, `UserShoppingLists`, `TermsOfUseShow`, `PrivacyPolicyShow`, and `AccountSetting` components

Fixes #238