### PR TITLE
feat(job): optimize menu sync by disabling recipe fetch and adding unique job constraints

### DIFF
--- a/app/Jobs/Recipe/FetchRecipeJob.php
+++ b/app/Jobs/Recipe/FetchRecipeJob.php
@@ -7,12 +7,13 @@ use App\Http\Clients\HelloFresh\HelloFreshClient;
 use App\Jobs\Concerns\HandlesApiFailuresTrait;
 use App\Models\Country;
 use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 
-class FetchRecipeJob implements ShouldQueue
+class FetchRecipeJob implements ShouldBeUnique, ShouldQueue
 {
     use Batchable;
     use HandlesApiFailuresTrait;
@@ -22,6 +23,19 @@ class FetchRecipeJob implements ShouldQueue
      * The number of times the job may be attempted.
      */
     public int $tries = 3;
+
+    /**
+     * The number of seconds after which the job's unique lock will be released.
+     */
+    public int $uniqueFor = 300;
+
+    /**
+     * The unique ID of the job.
+     */
+    public function uniqueId(): string
+    {
+        return $this->country->id . '-' . $this->hellofreshId;
+    }
 
     /**
      * Create a new job instance.

--- a/routes/console.php
+++ b/routes/console.php
@@ -29,7 +29,7 @@ Schedule::job(new SyncRecipesJob())
     ]);
 
 Schedule::job(new SyncMenusJob())
-    ->twiceDaily();
+    ->twiceDailyAt(6, 18);
 
 Schedule::job(new CountryResourcesOrchestrationJob())
     ->twiceDaily();


### PR DESCRIPTION

- Disable missing recipe fetch during menu sync to reduce API calls, with a note to monitor data quality
- Update `FetchMenuJob` to sync menus with existing recipes only
- Make `FetchRecipeJob` implement `ShouldBeUnique` to prevent duplicate processing
- Add unique constraints and timeout to `FetchRecipeJob` for better queue management
- Adjust `SyncMenusJob` scheduling to run at 6 AM and 6 PM