### PR TITLE
fix(og-image): handle empty image content in `imagecreatefromstring`

### DIFF
--- a/app/Http/Controllers/OgImageController.php
+++ b/app/Http/Controllers/OgImageController.php
@@ -178,6 +178,10 @@ class OgImageController extends Controller
 
         $imageContent = $response->body();
 
+        if ($imageContent === '') {
+            return false;
+        }
+
         $sourceImage = imagecreatefromstring($imageContent);
 
         if ($sourceImage === false) {


### PR DESCRIPTION
- Return `false` if the image content is empty to prevent errors when creating an image resource

fixes #301