### PR TITLE
feat(job): add `take` parameter to `FetchRecipePageJob` for enhanced control over API pagination

### DIFF
--- a/app/Http/Clients/HelloFresh/HelloFreshClient.php
+++ b/app/Http/Clients/HelloFresh/HelloFreshClient.php
@@ -166,9 +166,13 @@ class HelloFreshClient
      * @throws ConnectionException
      * @throws RequestException
      */
-    public function getRecipes(Country $country, string $locale, int $skip = 0): RecipesResponse
+    public function getRecipes(Country $country, string $locale, int $skip = 0, ?int $take = null): RecipesResponse
     {
         $countryCode = Str::upper($country->code);
+
+        if ($take === null) {
+            $take = $country->take;
+        }
 
         $url = sprintf(
             '%s/gw/api/recipes?country=%s&locale=%s-%s&take=%d&skip=%d',
@@ -176,7 +180,7 @@ class HelloFreshClient
             $countryCode,
             Str::lower($locale),
             $countryCode,
-            $country->take,
+            $take,
             $skip,
         );
 

--- a/app/Jobs/Recipe/FetchRecipePageJob.php
+++ b/app/Jobs/Recipe/FetchRecipePageJob.php
@@ -5,7 +5,6 @@ namespace App\Jobs\Recipe;
 use App\Contracts\LauncherJobInterface;
 use App\Enums\QueueEnum;
 use App\Http\Clients\HelloFresh\HelloFreshClient;
-use App\Jobs\Concerns\HandlesApiFailuresTrait;
 use App\Models\Country;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -13,20 +12,20 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
 
 /**
- * @method static void dispatch(Country $country, string $locale, int $skip = 0, bool $paginates = true)
+ * @method static void dispatch(Country $country, string $locale, int $skip = 0, bool $paginates = true, ?int $take = null)
  */
 class FetchRecipePageJob implements LauncherJobInterface, ShouldQueue
 {
     use Batchable;
-    use HandlesApiFailuresTrait;
     use Queueable;
 
     /**
      * The number of times the job may be attempted.
      */
-    public int $tries = 3;
+    public int $tries = 5;
 
     /**
      * Create a new job instance.
@@ -36,8 +35,13 @@ class FetchRecipePageJob implements LauncherJobInterface, ShouldQueue
         public string $locale,
         public int $skip = 0,
         public bool $paginates = true,
+        public ?int $take = null
     ) {
         $this->onQueue(QueueEnum::HelloFresh->value);
+
+        if ($take === null) {
+            $this->take = $country->take;
+        }
     }
 
     /**
@@ -67,18 +71,8 @@ class FetchRecipePageJob implements LauncherJobInterface, ShouldQueue
         ]);
 
         try {
-            $response = $client->withOutThrow()
-                ->getRecipes($this->country, $this->locale, $this->skip);
-        } catch (ConnectionException $connectionException) {
-            $this->handleApiFailure($connectionException);
-
-            return;
-        }
-
-        if ($response->failed()) {
-            $exception = $response->toException();
-            assert($exception !== null);
-
+            $response = $client->getRecipes($this->country, $this->locale, $this->skip, $this->take);
+        } catch (ConnectionException|RequestException $exception) {
             $this->handleApiFailure($exception);
 
             return;
@@ -91,7 +85,35 @@ class FetchRecipePageJob implements LauncherJobInterface, ShouldQueue
 
         // Only add next page fetch to batch if pagination is enabled
         if ($this->paginates && $response->hasMorePages()) {
-            $this->batch()?->add([new self($this->country, $this->locale, $response->nextSkip(), paginates: true)]);
+            $this->batch()?->add([new self($this->country, $this->locale, $response->nextSkip(), paginates: true, take: $this->take)]);
         }
+    }
+
+    /**
+     * Handle a failed API request with logging and retry logic.
+     *
+     * @throws ConnectionException
+     * @throws RequestException
+     */
+    protected function handleApiFailure(ConnectionException|RequestException $exception): void
+    {
+        $isLastAttempt = $this->attempts() >= $this->tries;
+
+        if ($isLastAttempt) {
+            throw $exception;
+        }
+
+        Log::warning(static::class . ' failed, retrying', [
+            'attempt' => $this->attempts(),
+            'exception' => $exception->getMessage(),
+        ]);
+
+        if ($this->take > 50 && $exception instanceof RequestException && $exception->response->serverError()) {
+            self::dispatch($this->country, $this->locale, $this->skip, $this->paginates, $this->take - 50);
+
+            return;
+        }
+
+        $this->release(30);
     }
 }


### PR DESCRIPTION
- Extend the `HelloFreshClient::getRecipes` method with a `take` parameter to allow dynamic batch sizes
- Update `FetchRecipePageJob` to support custom `take` values or default to the `Country` model's `take` attribute
- Increase `FetchRecipePageJob::tries` from 3 to 5 for improved retry handling
- Introduce retry logic for server errors by progressively reducing the `take` value
- Add new test cases to validate `take` functionality, error handling, and retry behavior