### PR TITLE
fix(bring): add missing author property for valid Schema.org Recipe format

### DIFF
--- a/resources/views/web/bring-export.blade.php
+++ b/resources/views/web/bring-export.blade.php
@@ -14,11 +14,18 @@
         '@context' => 'https://schema.org',
         '@type' => 'Recipe',
         'name' => __('Shopping List'),
+        'author' => [
+            '@type' => 'Organization',
+            'name' => 'HelloFresh',
+        ],
         'recipeIngredient' => $ingredientStrings,
     ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) !!}</script>
 </head>
 <body itemscope itemtype="https://schema.org/Recipe">
     <h1 itemprop="name">{{ __('Shopping List') }}</h1>
+    <span itemprop="author" itemscope itemtype="https://schema.org/Organization">
+        <meta itemprop="name" content="HelloFresh">
+    </span>
     <ul>
         @foreach ($ingredients as $ingredient)
             <li itemprop="recipeIngredient">


### PR DESCRIPTION
## Summary
- Add `author` property (HelloFresh) to the Schema.org Recipe JSON-LD and HTML microdata in the Bring! export view
- Bring! requires `author`, `name`, and `recipeIngredient` as mandatory fields — the missing `author` caused the "imported recipe has no valid format" error

## Test plan
- [ ] Export a shopping list to Bring! and verify it imports without error
- [ ] Verify the JSON-LD output includes the `author` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)