### PR TITLE
feat(recipe): update search logic to support content locale filtering

### DIFF
--- a/app/Http/Controllers/Api/Localized/RecipeController.php
+++ b/app/Http/Controllers/Api/Localized/RecipeController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\Api\RecipeIndexRequest;
 use App\Http\Resources\Api\RecipeCollection;
 use App\Http\Resources\Api\RecipeResource;
 use App\Models\Recipe;
+use App\Support\Api\ContentLocale;
 use Illuminate\Database\Eloquent\Builder;
 use Throwable;
 
@@ -23,7 +24,7 @@ class RecipeController extends AbstractLocalizedController
                 ->with(['label', 'tags'])
                 ->when($request->filled('search'), function (Builder $query) use ($request): void {
                     $searchTerm = '%' . $request->string('search') . '%';
-                    $locale = app()->getLocale();
+                    $locale = ContentLocale::get();
 
                     $query->where(function (Builder $query) use ($searchTerm, $locale): void {
                         $query->whereLike('name->' . $locale, $searchTerm)

--- a/tests/Feature/Http/Controllers/Api/Localized/RecipeControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/Localized/RecipeControllerTest.php
@@ -114,8 +114,6 @@ final class RecipeControllerTest extends TestCase
     #[Test]
     public function it_filters_recipes_by_search_term(): void
     {
-        // Note: Search uses app locale which is set by ApiLocalizationMiddleware
-        // The URL prefix de-DE sets the locale to 'de'
         Recipe::factory()->for($this->country)->create([
             'name' => ['de' => 'Spaghetti Carbonara', 'en' => 'Spaghetti Carbonara'],
         ]);
@@ -129,6 +127,24 @@ final class RecipeControllerTest extends TestCase
         $response->assertOk()
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.name', 'Spaghetti Carbonara');
+    }
+
+    #[Test]
+    public function it_filters_recipes_by_search_term_using_content_locale(): void
+    {
+        Recipe::factory()->for($this->country)->create([
+            'name' => ['de' => 'Hähnchen Teriyaki', 'en' => 'Chicken Teriyaki'],
+        ]);
+
+        Recipe::factory()->for($this->country)->create([
+            'name' => ['de' => 'Pizza Margherita', 'en' => 'Pizza Margherita'],
+        ]);
+
+        $response = $this->apiGet('/de-DE/recipes?search=Hähnchen');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Hähnchen Teriyaki');
     }
 
     #[Test]


### PR DESCRIPTION
- Use `ContentLocale::get()` to determine locale for search queries instead of app locale
- Add new test case to verify recipe search functionality with content locale

fixes #306