### PR TITLE
docs: add detailed report on tag and label naming inconsistencies across countries

### DIFF
--- a/docs/tag-label-naming-inconsistencies.md
+++ b/docs/tag-label-naming-inconsistencies.md
@@ -1,0 +1,90 @@
+> # Tag & Label Naming Inconsistencies
+> 
+> This document outlines naming inconsistencies for Thermomix and Air Fryer across countries.
+> 
+> ## Thermomix
+> 
+> ### Tags
+> 
+> | Country | Locale | Tag Name                  |
+> |---------|--------|---------------------------|
+> | DE      | de     | Thermomix                 |
+> | AT      | de     | Thermomix                 |
+> | CH      | de     | Thermomix                 |
+> | FR      | fr     | Thermomix                 |
+> | IE      | en     | Thermomix                 |
+> | DE      | de     | Thermomix hilft           |
+> | AT      | de     | Thermomix hilft           |
+> | DE      | de     | Thermomix kocht           |
+> | AT      | de     | Thermomix kocht           |
+> | DE      | de     | Thermomix übernimmt alles |
+> | AT      | de     | Thermomix übernimmt alles |
+> | CH      | de     | Thermomix übernimmt alles |
+> 
+> ### Labels
+> 
+> | Country | Locale | Label Name |
+> |---------|--------|------------|
+> | DE      | de     | Thermomix  |
+> | AT      | de     | Thermomix  |
+> | CH      | de     | Thermomix  |
+> 
+> ### Summary
+> 
+> Thermomix naming is relatively consistent. The base name `Thermomix` is the same everywhere. The DACH region has additional sub-tags (`hilft`, `kocht`, `übernimmt alles`) that describe the level of Thermomix involvement. No Air Fryer-level inconsistencies here.
+> 
+> ## Air Fryer
+> 
+> ### Tags
+> 
+> | Country | Locale | Tag Name             |
+> |---------|--------|----------------------|
+> | DE      | de     | Air Fryer Easy       |
+> | AT      | de     | Air Fryer Easy       |
+> | CH      | de     | Air Fryer Easy       |
+> | AU      | en     | Air Fryer Easy       |
+> | AU      | en     | Air Fryer Friendly   |
+> | NZ      | en     | Air Fryer Easy       |
+> | NZ      | en     | Air Fryer Friendly   |
+> | GB      | en     | Air Fryer Friendly   |
+> | FR      | fr     | Compatible Air Fryer |
+> | BE      | fr/nl  | Air Fryer Easy       |
+> | BE      | fr/nl  | Philips Airfryer     |
+> | LU      | fr     | Air Fryer Easy       |
+> | LU      | fr     | Philips Airfryer     |
+> | NL      | nl     | Air Fryer Easy       |
+> | NL      | nl     | Philips Airfryer     |
+> 
+> ### Labels
+> 
+> | Country | Locale | Label Name         |
+> |---------|--------|--------------------|
+> | DE      | de     | Air-Fryer          |
+> | AT      | de     | Air-Fryer          |
+> | GB      | en     | Air Fryer Friendly |
+> | BE      | fr/nl  | OPTION AIRFRYER    |
+> | LU      | fr     | OPTION AIRFRYER    |
+> | NL      | nl     | AIRFRYER OPTIONEEL |
+> 
+> ### Summary
+> 
+> Air Fryer naming is highly inconsistent across countries:
+> 
+> - **6 different spelling variants** across tags and labels
+> - **Inconsistent casing**: `Air Fryer Easy` vs `OPTION AIRFRYER` vs `AIRFRYER OPTIONEEL`
+> - **Inconsistent spacing/punctuation**: `Air Fryer` vs `Air-Fryer` vs `Airfryer`
+> - **Brand-specific names**: `Philips Airfryer` (BE, LU, NL)
+> - **Language-specific phrasing**: `Compatible Air Fryer` (FR), `AIRFRYER OPTIONEEL` (NL)
+> - **Missing labels**: FR has no Air Fryer label at all
+> - **DE/AT label uses a hyphen** (`Air-Fryer`) while the tag does not (`Air Fryer Easy`)
+> 
+> ## Countries Without Any Thermomix or Air Fryer Tags/Labels
+> 
+> The following active countries have neither Thermomix nor Air Fryer tags or labels:
+> 
+> - DK (Denmark)
+> - ES (Spain)
+> - IT (Italy)
+> - NO (Norway)
+> - SE (Sweden)
+> - US (United States)


### PR DESCRIPTION
- Document inconsistencies in Thermomix and Air Fryer naming conventions for tags and labels
- Highlight differences in spelling, casing, spacing, and brand usage
- Include summary of countries missing tags/labels